### PR TITLE
Fix scoring info

### DIFF
--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -66,7 +66,7 @@
             <h4>Reglas de la Penca</h4>
             <h5>Puntajes</h5>
             <p>
-                - Resultado exacto da 4 puntos.
+                - Resultado exacto da 3 puntos.
                 - Indicar resultado (ganador o empate) da 1 punto.
                 - Adivinar la cantidad de goles de uno de los dos equipos da 1 punto adicional.
             </p>


### PR DESCRIPTION
## Summary
- correct scoring description in dashboard modal

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c05627f688325b988e61443cd4026