### PR TITLE
Add Jest and ranking route test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,27 +1,29 @@
 {
-    "name": "penca_copa_america",
-    "version": "1.0.0",
-    "description": "Plataforma de penca para la Copa América 2024",
-    "main": "main.js",
-    "scripts": {
-      "start": "node main.js",
-      "dev": "nodemon main.js"
-    },
-    "dependencies": {
-      "bcrypt": "^5.0.1",
-      "body-parser": "^1.19.0",
-      "connect-mongo": "^4.6.0",
-      "dotenv": "^10.0.0",
-      "express": "^4.17.1",
-      "express-session": "^1.17.1",
-      "mongoose": "^6.0.12",
-      "multer": "^1.4.4",
-      "ejs": "^3.1.6"
-    },
-    "devDependencies": {
-      "nodemon": "^2.0.12"
-    },
-    "author": "Ren",
-    "license": "ISC"
-  }
-  
+  "name": "penca_copa_america",
+  "version": "1.0.0",
+  "description": "Plataforma de penca para la Copa América 2024",
+  "main": "main.js",
+  "scripts": {
+    "start": "node main.js",
+    "dev": "nodemon main.js",
+    "test": "jest"
+  },
+  "dependencies": {
+    "bcrypt": "^5.0.1",
+    "body-parser": "^1.19.0",
+    "connect-mongo": "^4.6.0",
+    "dotenv": "^10.0.0",
+    "express": "^4.17.1",
+    "express-session": "^1.17.1",
+    "mongoose": "^6.0.12",
+    "multer": "^1.4.4",
+    "ejs": "^3.1.6"
+  },
+  "devDependencies": {
+    "nodemon": "^2.0.12",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
+  },
+  "author": "Ren",
+  "license": "ISC"
+}

--- a/tests/ranking.test.js
+++ b/tests/ranking.test.js
@@ -1,0 +1,29 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../models/User', () => ({ find: jest.fn() }));
+jest.mock('../models/Match', () => ({ find: jest.fn() }));
+jest.mock('../models/Prediction', () => ({ find: jest.fn() }));
+
+const User = require('../models/User');
+const Match = require('../models/Match');
+const Prediction = require('../models/Prediction');
+const rankingRouter = require('../routes/ranking');
+
+describe('GET /ranking', () => {
+  it('returns an array of scores', async () => {
+    User.find.mockResolvedValue([{ _id: 'u1', username: 'testuser' }]);
+    Match.find.mockResolvedValue([{ _id: 'm1', result1: 1, result2: 0 }]);
+    Prediction.find.mockResolvedValue([
+      { userId: 'u1', matchId: 'm1', result1: 1, result2: 0 },
+    ]);
+
+    const app = express();
+    app.use('/ranking', rankingRouter);
+
+    const res = await request(app).get('/ranking');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body[0]).toHaveProperty('score');
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest and Supertest dev dependencies
- add npm test script
- create ranking.test.js to verify `/ranking` returns a score array

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c0561c704832594fc6e89ceee8a04