### PR TITLE
Remove unused node-fetch import

### DIFF
--- a/routes/matches.js
+++ b/routes/matches.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const router = express.Router();
 const Match = require('../models/Match');
-const fetch = require('node-fetch');
 const { isAdmin } = require('../middleware/auth');
 
 router.get('/', async (req, res) => {
@@ -25,7 +24,6 @@ router.post('/:id', isAdmin, async (req, res) => {
         await match.save();
         res.json({ message: 'Match result updated' });
         // Recalcular puntaje de todos los usuarios
-        //await fetch('/ranking/recalculate', { method: 'POST' });
     } catch (err) {
         res.status(500).json({ error: 'Error updating match result' });
     }


### PR DESCRIPTION
## Summary
- clean up `routes/matches.js` by removing an unused `node-fetch` import
- delete commented call that referenced `fetch`

## Testing
- `node -e "require('./routes/matches.js')"` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685c055fb0d48325bb641395b2c64b10