### PR TITLE
Fix text on admin reset button

### DIFF
--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -19,7 +19,7 @@
                     <img src="/images/info.png" alt="Info" class="circle responsive-img">
                 </a>
                 <% if (user.role === 'admin') { %>
-                    <a id="reset-matches-btn" class="btn red" style="margin-right: 10px;">Reestablecer Partidos</a>
+                    <a id="reset-matches-btn" class="btn red" style="margin-right: 10px;">Restablecer Partidos</a>
                 <% } %>
                 <a class="dropdown-trigger" href="#!" data-target="user-dropdown">
                     <img src="<%= user.avatar ? '/avatar/' + user.username : '/images/avatar.webp' %>" alt="Avatar" class="circle responsive-img">


### PR DESCRIPTION
## Summary
- correct typo in dashboard reset-matches button

## Testing
- `grep -n "Restablecer Partidos" -n views/dashboard.ejs`


------
https://chatgpt.com/codex/tasks/task_e_685c055f40048325b574524a44ece40b