### PR TITLE
Initialize DB with default admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ npm run dev
 
 Para un entorno de producción puedes utilizar `npm start`.
 
+Al iniciarse por primera vez, la aplicación comprobará que exista la base de datos
+e insertará un usuario administrador por defecto si es necesario. Las credenciales
+iniciales son:
+
+- **Usuario:** `admin`
+- **Contraseña:** `Penca2024Ren`
+
 ## Estructura del proyecto
 
 - **main.js** – punto de entrada de la aplicación y configuración de Express.


### PR DESCRIPTION
## Summary
- ensure DB and default admin user are created at start up
- document default admin credentials in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c1bf6f6dc83259af380a287b016df