### PR TITLE
Initialize matches if none exist

### DIFF
--- a/main.js
+++ b/main.js
@@ -78,22 +78,20 @@ async function initializeDatabase() {
                 username: adminUsername,
                 password: hashedPassword,
                 email: adminEmail,
-        let admin = await User.findOne({ username: 'admin' });
-        if (!admin) {
-            console.log('No existe usuario administrador, creándolo...');
-            const hashedPassword = await bcrypt.hash('Penca2024Ren', 10);
-            admin = new User({
-                username: 'admin',
-                password: hashedPassword,
-                email: 'admin@example.com',
                 role: 'admin',
                 valid: true
             });
             await admin.save();
-
             await Score.create({ userId: admin._id, competition: 'Copa America 2024' });
-
             console.log('Usuario administrador creado.');
+        }
+
+        // Prepopular partidos si la colección está vacía
+        const matchCount = await Match.countDocuments();
+        if (matchCount === 0) {
+            const matches = require('./matches.json');
+            await Match.insertMany(matches);
+            console.log('Partidos prepopulados.');
         }
     } catch (error) {
         console.error('Error al inicializar la base de datos:', error);


### PR DESCRIPTION
## Summary
- prepopulate the database with matches if collection is empty
- clean up duplicate initialization code

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c252f8480832580ae0ba473acb7f8