### PR TITLE
Fix duplicate admin creation block

### DIFF
--- a/main.js
+++ b/main.js
@@ -78,14 +78,6 @@ async function initializeDatabase() {
                 username: adminUsername,
                 password: hashedPassword,
                 email: adminEmail,
-        let admin = await User.findOne({ username: 'admin' });
-        if (!admin) {
-            console.log('No existe usuario administrador, creándolo...');
-            const hashedPassword = await bcrypt.hash('Penca2024Ren', 10);
-            admin = new User({
-                username: 'admin',
-                password: hashedPassword,
-                email: 'admin@example.com',
                 role: 'admin',
                 valid: true
             });


### PR DESCRIPTION
## Summary
- fix `initializeDatabase` by removing duplicate admin lookup
- ensure default admin is created with `role` and `valid` fields

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c252db36883258b45a508b5d8b0f9