### PR TITLE
Add SESSION_SECRET env var

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,1 @@
 MONGODB_URI=mongodb+srv://admindbpenca:AdminDbPenca2024Ren@pencacopaamerica2024.yispiqt.mongodb.net/penca_copa_america?retryWrites=true&w=majority&appName=PencaCopaAmerica2024
-SESSION_SECRET='secret'

--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 MONGODB_URI=mongodb+srv://admindbpenca:AdminDbPenca2024Ren@pencacopaamerica2024.yispiqt.mongodb.net/penca_copa_america?retryWrites=true&w=majority&appName=PencaCopaAmerica2024
+SESSION_SECRET=cambiaestevalor

--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
 MONGODB_URI=mongodb+srv://admindbpenca:AdminDbPenca2024Ren@pencacopaamerica2024.yispiqt.mongodb.net/penca_copa_america?retryWrites=true&w=majority&appName=PencaCopaAmerica2024
-SESSION_SECRET=cambiaestevalor
+SESSION_SECRET='secret'

--- a/README.md
+++ b/README.md
@@ -19,11 +19,6 @@ proyecto con al menos la URL de tu base de datos MongoDB:
 MONGODB_URI=mongodb://<usuario>:<password>@<host>/<basedatos>
 # Opcionalmente puedes definir el puerto de la app
 PORT=3000
-# Credenciales del administrador por defecto
-DEFAULT_ADMIN_USERNAME=admin
-DEFAULT_ADMIN_PASSWORD=Penca2024Ren
-# Secreto de la sesión
-SESSION_SECRET=cambiaestevalor
 ```
 
 3. Inicia el servidor en modo desarrollo con **nodemon**:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ PORT=3000
 # Credenciales del administrador por defecto
 DEFAULT_ADMIN_USERNAME=admin
 DEFAULT_ADMIN_PASSWORD=Penca2024Ren
+# Secreto de la sesión
+SESSION_SECRET=cambiaestevalor
 ```
 
 3. Inicia el servidor en modo desarrollo con **nodemon**:

--- a/main.js
+++ b/main.js
@@ -13,6 +13,13 @@ const ejs = require('ejs');
 
 dotenv.config();
 
+if (!process.env.SESSION_SECRET) {
+    console.error('SESSION_SECRET is not defined. Exiting...');
+    process.exit(1);
+}
+
+const SESSION_SECRET = process.env.SESSION_SECRET;
+
 const app = express();
 const PORT = process.env.PORT || 3000;
 
@@ -37,7 +44,7 @@ app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
 
 app.use(session({
-    secret: 'secret',
+    secret: SESSION_SECRET,
     resave: false,
     saveUninitialized: false,
     store: MongoStore.create({


### PR DESCRIPTION
## Summary
- require `SESSION_SECRET` and use it for session config
- add the new env variable to the `.env` file and docs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c4453792083259a6cb1f29f8aaffe