### PR TITLE
Add tests for auth, matches and predictions

### DIFF
--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,0 +1,94 @@
+const request = require('supertest');
+const express = require('express');
+const session = require('express-session');
+const bodyParser = require('body-parser');
+const bcrypt = require('bcrypt');
+
+jest.mock('../models/User', () => {
+  const UserMock = jest.fn(function (data) {
+    Object.assign(this, data);
+    this.save = jest.fn().mockResolvedValue(this);
+  });
+  UserMock.findOne = jest.fn();
+  return UserMock;
+});
+
+jest.mock('../models/Score', () => {
+  return jest.fn(function (data) {
+    Object.assign(this, data);
+    this.save = jest.fn().mockResolvedValue(this);
+  });
+});
+
+const User = require('../models/User');
+const Score = require('../models/Score');
+
+describe('Auth Routes', () => {
+  let app;
+
+  beforeEach(() => {
+    app = express();
+    app.use(bodyParser.json());
+    app.use(session({ secret: 'test', resave: false, saveUninitialized: true }));
+
+    app.post('/login', async (req, res) => {
+      const { username, password } = req.body;
+      try {
+        const user = await User.findOne({ username });
+        if (!user) {
+          return res.status(401).json({ error: 'Usuario no encontrado' });
+        }
+        const passwordMatch = await bcrypt.compare(password, user.password);
+        if (!passwordMatch) {
+          return res.status(401).json({ error: 'Contraseña incorrecta' });
+        }
+        req.session.user = user;
+        res.json({ success: true, redirectUrl: '/dashboard' });
+      } catch (err) {
+        res.status(500).json({ error: 'Error interno del servidor' });
+      }
+    });
+
+    app.post('/register', async (req, res) => {
+      const { username, password, email } = req.body;
+      try {
+        const existingUser = await User.findOne({ $or: [{ username }, { email }] });
+        if (existingUser) {
+          return res.status(400).json({ error: 'El nombre de usuario o email ya existe' });
+        }
+        const hashedPassword = await bcrypt.hash(password, 10);
+        const user = new User({ username, password: hashedPassword, email });
+        await user.save();
+        const score = new Score({ userId: user._id, competition: 'Copa America 2024' });
+        await score.save();
+        req.session.user = user;
+        res.json({ success: true, redirectUrl: '/dashboard' });
+      } catch (err) {
+        res.status(500).json({ error: 'Error interno del servidor' });
+      }
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('logs in a user with valid credentials', async () => {
+    const hashed = await bcrypt.hash('pass', 10);
+    User.findOne.mockResolvedValue({ _id: '1', username: 'test', password: hashed });
+
+    const res = await request(app).post('/login').send({ username: 'test', password: 'pass' });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('registers a new user', async () => {
+    User.findOne.mockResolvedValue(null);
+
+    const res = await request(app).post('/register').send({ username: 'new', email: 'new@example.com', password: 'pass' });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(User).toHaveBeenCalledWith(expect.objectContaining({ username: 'new' }));
+  });
+});
+

--- a/tests/matches.test.js
+++ b/tests/matches.test.js
@@ -1,0 +1,37 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../models/Match', () => ({
+  find: jest.fn(),
+  findById: jest.fn()
+}));
+
+jest.mock('../middleware/auth', () => ({
+  isAdmin: jest.fn((req, res, next) => next())
+}));
+
+const Match = require('../models/Match');
+const matchesRouter = require('../routes/matches');
+
+describe('Match Routes', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('updates match results', async () => {
+    const save = jest.fn().mockResolvedValue(true);
+    Match.findById.mockResolvedValue({ save });
+
+    const app = express();
+    app.use(express.json());
+    app.use('/matches', matchesRouter);
+
+    const res = await request(app)
+      .post('/matches/1')
+      .send({ result1: 2, result2: 1 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Match result updated');
+    expect(save).toHaveBeenCalled();
+  });
+});

--- a/tests/predictions.test.js
+++ b/tests/predictions.test.js
@@ -1,0 +1,45 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../models/Prediction', () => {
+  const PredictionMock = jest.fn(function (data) {
+    Object.assign(this, data);
+    this.save = jest.fn().mockResolvedValue(this);
+  });
+  PredictionMock.find = jest.fn();
+  PredictionMock.findOne = jest.fn();
+  return PredictionMock;
+});
+
+jest.mock('../models/Match', () => ({
+  findById: jest.fn()
+}));
+
+const Prediction = require('../models/Prediction');
+const Match = require('../models/Match');
+const predictionsRouter = require('../routes/predictions');
+
+describe('Predictions Routes', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('saves a new prediction', async () => {
+    Prediction.findOne.mockResolvedValue(null);
+    const futureDate = new Date(Date.now() + 3600 * 1000).toISOString().split('T')[0];
+    Match.findById.mockResolvedValue({ date: futureDate, time: '23:59' });
+
+    const app = express();
+    app.use(express.json());
+    app.use((req, res, next) => { req.session = { user: { _id: 'u1', username: 'tester' } }; next(); });
+    app.use('/predictions', predictionsRouter);
+
+    const res = await request(app)
+      .post('/predictions')
+      .send({ matchId: 'm1', result1: 1, result2: 0 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Predicción guardada');
+    expect(Prediction).toHaveBeenCalledWith(expect.objectContaining({ userId: 'u1', matchId: 'm1' }));
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for login and register handlers
- mock match update route and add tests
- mock prediction logic and add tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c44573dec83258d7b55d9b466c891