### PR TITLE
Implement penca groups and ranking

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,14 @@ e insertará un usuario administrador por defecto si es necesario. Las credencia
 
 - **main.js** – punto de entrada de la aplicación y configuración de Express.
 - **middleware/** – middlewares de autenticación y control de caché.
-- **models/** – modelos de Mongoose (User, Match, Prediction, Score).
-- **routes/** – rutas de la aplicación: administración, partidos, predicciones y ranking.
+- **models/** – modelos de Mongoose (User, Match, Prediction, Score, Penca).
+- **routes/** – rutas de la aplicación: administración, partidos, predicciones, ranking y pencas.
 - **public/** – archivos estáticos (CSS, imágenes, scripts de cliente, uploads).
 - **views/** – plantillas EJS para las vistas HTML.
 - **matches.json** – datos de los partidos utilizados para inicializar la base.
 - **updateschema.js** – script auxiliar para crear o actualizar esquemas en MongoDB.
+
+El esquema `Penca` permite organizar competiciones privadas. Los usuarios se unen con un código y el propietario decide aprobar o eliminar participantes.
 
 Con esta estructura puedes navegar fácilmente por cada componente de la aplicación.
 

--- a/main.js
+++ b/main.js
@@ -78,6 +78,7 @@ const Score = require('./models/Score');
 const Match = require('./models/Match');
 const Prediction = require('./models/Prediction');
 const adminRouter = require('./routes/admin');
+const pencaRouter = require('./routes/penca');
 
 async function initializeDatabase() {
     try {
@@ -234,6 +235,7 @@ app.get('/avatar/:username', async (req, res) => {
 app.use('/matches', isAuthenticated, require('./routes/matches'));
 app.use('/predictions', isAuthenticated, require('./routes/predictions'));
 app.use('/ranking', isAuthenticated, require('./routes/ranking'));
+app.use('/pencas', isAuthenticated, pencaRouter);
 app.use('/admin', adminRouter);
 
 app.post('/logout', (req, res) => {

--- a/models/Penca.js
+++ b/models/Penca.js
@@ -1,0 +1,13 @@
+const mongoose = require('mongoose');
+
+const pencaSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  code: { type: String, required: true, unique: true },
+  owner: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  participantLimit: { type: Number, default: 20 },
+  fixture: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Match' }],
+  participants: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
+  pendingRequests: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }]
+});
+
+module.exports = mongoose.models.Penca || mongoose.model('Penca', pencaSchema);

--- a/models/Prediction.js
+++ b/models/Prediction.js
@@ -4,10 +4,11 @@ const predictionSchema = new mongoose.Schema({
     userId: { type: mongoose.Schema.Types.ObjectId, required: true },
     username: { type: String, required: true },
     matchId: { type: mongoose.Schema.Types.ObjectId, required: true },
+    pencaId: { type: mongoose.Schema.Types.ObjectId, ref: 'Penca', required: true },
     result1: { type: Number, required: true },
     result2: { type: Number, required: true },
 });
 
-predictionSchema.index({ userId: 1, matchId: 1 }, { unique: true });
+predictionSchema.index({ userId: 1, matchId: 1, pencaId: 1 }, { unique: true });
 
 module.exports = mongoose.models.Prediction || mongoose.model('Prediction', predictionSchema);

--- a/models/User.js
+++ b/models/User.js
@@ -9,8 +9,10 @@ const userSchema = new mongoose.Schema({
     dob: { type: Date, required: false },
     avatar: { type: Buffer, required: false },
     avatarContentType: { type: String, required: false },
-    role: { type: String, default: 'user' },
-    valid: { type: Boolean, default: false }
+    role: { type: String, enum: ['user', 'owner', 'admin'], default: 'user' },
+    valid: { type: Boolean, default: false },
+    ownedPencas: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Penca' }],
+    pencas: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Penca' }]
 });
 
 const User = mongoose.model('User', userSchema);

--- a/routes/penca.js
+++ b/routes/penca.js
@@ -1,0 +1,74 @@
+const express = require('express');
+const router = express.Router();
+const Penca = require('../models/Penca');
+const User = require('../models/User');
+const { isAuthenticated } = require('../middleware/auth');
+
+// Solicitar unirse a una penca mediante el codigo
+router.post('/join', isAuthenticated, async (req, res) => {
+  const { code } = req.body;
+  const userId = req.session.user._id;
+  try {
+    const penca = await Penca.findOne({ code });
+    if (!penca) return res.status(404).json({ error: 'Penca not found' });
+
+    if (penca.participants.includes(userId) || penca.pendingRequests.includes(userId)) {
+      return res.status(400).json({ error: 'Already requested or member' });
+    }
+    if (penca.participantLimit && penca.participants.length >= penca.participantLimit) {
+      return res.status(400).json({ error: 'Penca is full' });
+    }
+    penca.pendingRequests.push(userId);
+    await penca.save();
+    res.json({ message: 'Request sent' });
+  } catch (err) {
+    console.error('join penca error', err);
+    res.status(500).json({ error: 'Error joining penca' });
+  }
+});
+
+// Aprobar solicitud de participante
+router.post('/approve/:pencaId/:userId', isAuthenticated, async (req, res) => {
+  const { pencaId, userId } = req.params;
+  const sessionUser = req.session.user;
+  try {
+    const penca = await Penca.findById(pencaId);
+    if (!penca) return res.status(404).json({ error: 'Penca not found' });
+    if (penca.owner.toString() !== sessionUser._id.toString()) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    penca.pendingRequests = penca.pendingRequests.filter(id => id.toString() !== userId);
+    if (!penca.participants.includes(userId)) {
+      penca.participants.push(userId);
+      await User.updateOne({ _id: userId }, { $addToSet: { pencas: penca._id } });
+    }
+    await penca.save();
+    res.json({ message: 'Participant approved' });
+  } catch (err) {
+    console.error('approve participant error', err);
+    res.status(500).json({ error: 'Error approving participant' });
+  }
+});
+
+// Eliminar participante
+router.delete('/participant/:pencaId/:userId', isAuthenticated, async (req, res) => {
+  const { pencaId, userId } = req.params;
+  const sessionUser = req.session.user;
+  try {
+    const penca = await Penca.findById(pencaId);
+    if (!penca) return res.status(404).json({ error: 'Penca not found' });
+    if (penca.owner.toString() !== sessionUser._id.toString()) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    penca.participants = penca.participants.filter(id => id.toString() !== userId);
+    penca.pendingRequests = penca.pendingRequests.filter(id => id.toString() !== userId);
+    await penca.save();
+    await User.updateOne({ _id: userId }, { $pull: { pencas: penca._id } });
+    res.json({ message: 'Participant removed' });
+  } catch (err) {
+    console.error('remove participant error', err);
+    res.status(500).json({ error: 'Error removing participant' });
+  }
+});
+
+module.exports = router;

--- a/routes/ranking.js
+++ b/routes/ranking.js
@@ -6,10 +6,11 @@ const Match = require('../models/Match');
 const Score = require('../models/Score');
 
 // Función para calcular los puntajes
-async function calculateScores() {
+async function calculateScores(pencaId) {
     const users = await User.find({ valid: true });
     const matches = await Match.find();
-    const predictions = await Prediction.find();
+    const filter = pencaId ? { pencaId } : {};
+    const predictions = await Prediction.find(filter);
 
     let scores = [];
 
@@ -53,7 +54,8 @@ async function calculateScores() {
 // Endpoint para obtener el ranking
 router.get('/', async (req, res) => {
     try {
-        const scores = await calculateScores();
+        const { pencaId } = req.query;
+        const scores = await calculateScores(pencaId);
         res.json(scores);
     } catch (err) {
         console.error('Error al obtener el ranking:', err);
@@ -64,7 +66,8 @@ router.get('/', async (req, res) => {
 // Endpoint para recalcular los puntajes
 router.post('/recalculate', async (req, res) => {
     try {
-        const scores = await calculateScores();
+        const { pencaId } = req.query;
+        const scores = await calculateScores(pencaId);
         for (let score of scores) {
             await Score.updateOne(
                 { userId: score.userId, competition: 'Copa América 2024' },


### PR DESCRIPTION
## Summary
- create `Penca` model to manage private groups
- extend `User` with `owner` role and penca relations
- store `pencaId` in predictions
- add routes for joining a penca, approving or removing participants
- support per-penca ranking calculations
- document penca model in README

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c44589bc4832580d1a5fc9aabc6d2