### PR TITLE
Implement basic penca management UI

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -310,4 +310,49 @@ document.addEventListener('DOMContentLoaded', async function() {
         }
     };
     avatarRequest.send();
+
+    // Solicitar unirse a una penca
+    const joinBtn = document.getElementById('join-button');
+    if (joinBtn) {
+        joinBtn.addEventListener('click', async () => {
+            const code = document.getElementById('join-code').value;
+            try {
+                const resp = await fetch('/pencas/join', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({ code })
+                });
+                const data = await resp.json();
+                const msg = document.getElementById('join-message');
+                if (resp.ok) {
+                    msg.textContent = data.message;
+                    msg.className = 'green-text';
+                } else {
+                    msg.textContent = data.error || 'Error';
+                    msg.className = 'red-text';
+                }
+            } catch (err) {
+                console.error('join penca error', err);
+            }
+        });
+    }
+
+    // Cargar solicitudes y participantes para owners
+    if (userRole === 'owner') {
+        try {
+            const resp = await fetch('/pencas/mine');
+            const pencas = await resp.json();
+            const container = document.getElementById('manage-content');
+            pencas.forEach(penca => {
+                const div = document.createElement('div');
+                div.innerHTML = `<h5>${penca.name}</h5>`;
+                const pending = document.createElement('ul');
+                pending.innerHTML = penca.pendingRequests.map(u => `<li>${u}</li>`).join('');
+                div.appendChild(pending);
+                container.appendChild(div);
+            });
+        } catch (err) {
+            console.error('load owner pencas error', err);
+        }
+    }
 });

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -33,9 +33,13 @@
     <main>
         <div class="container">
             <ul class="tabs">
-                <li class="tab col s3"><a href="#fixture" class="<%= user.role === 'admin' ? 'active' : '' %>">Fixture</a></li>
-                <li class="tab col s3"><a href="#predictions" class="<%= user.role !== 'admin' ? 'active' : '' %>">Predicciones</a></li>
-                <li class="tab col s3"><a href="#ranking">Ranking</a></li>
+                <li class="tab col s2"><a href="#fixture" class="<%= user.role === 'admin' ? 'active' : '' %>">Fixture</a></li>
+                <li class="tab col s2"><a href="#predictions" class="<%= user.role !== 'admin' ? 'active' : '' %>">Predicciones</a></li>
+                <li class="tab col s2"><a href="#ranking">Ranking</a></li>
+                <li class="tab col s2"><a href="#join">Unirse</a></li>
+                <% if (user.role === 'owner') { %>
+                    <li class="tab col s2"><a href="#manage">Mi Penca</a></li>
+                <% } %>
             </ul>
             
             <div id="fixture" class="col s12">
@@ -47,6 +51,23 @@
             <div id="ranking" class="col s12">
                 <div id="ranking-list" class="row"></div>
             </div>
+            <div id="join" class="col s12">
+                <div class="row">
+                    <div class="input-field col s12 m6">
+                        <input id="join-code" type="text">
+                        <label for="join-code">Código de Penca</label>
+                    </div>
+                    <div class="col s12 m6">
+                        <button id="join-button" class="btn waves-effect waves-light">Solicitar Unirse</button>
+                    </div>
+                    <div id="join-message" class="col s12"></div>
+                </div>
+            </div>
+            <% if (user.role === 'owner') { %>
+            <div id="manage" class="col s12">
+                <div id="manage-content" class="row"></div>
+            </div>
+            <% } %>
         </div>
     </main>
     <footer class="page-footer blue darken-3">


### PR DESCRIPTION
## Summary
- add penca listing and owner endpoints
- update dashboard with join and manage sections
- add client scripts to join a penca and view owner requests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c3534f7e083259c17e0ea3cb75b50