### PR TITLE
Implement admin Penca creation endpoint

### DIFF
--- a/tests/admin.test.js
+++ b/tests/admin.test.js
@@ -1,0 +1,58 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../models/Penca', () => {
+  return jest.fn(function (data) {
+    Object.assign(this, data);
+    this.save = jest.fn().mockResolvedValue(this);
+  });
+});
+
+jest.mock('../models/Match', () => ({
+  insertMany: jest.fn()
+}));
+
+jest.mock('../models/User', () => ({
+  findById: jest.fn()
+}));
+
+jest.mock('../middleware/auth', () => ({
+  isAuthenticated: jest.fn((req, res, next) => next()),
+  isAdmin: jest.fn((req, res, next) => next())
+}));
+
+const Penca = require('../models/Penca');
+const Match = require('../models/Match');
+const User = require('../models/User');
+const adminRouter = require('../routes/admin');
+
+describe('Admin penca creation', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates a penca and loads matches', async () => {
+    User.findById.mockResolvedValue({ _id: 'u1', ownedPencas: [], save: jest.fn().mockResolvedValue(true) });
+    Match.insertMany.mockResolvedValue([{ _id: 'm1' }]);
+
+    const app = express();
+    app.use('/admin', adminRouter);
+
+    const fixture = [{ team1: 'A', team2: 'B' }];
+
+    const res = await request(app)
+      .post('/admin/pencas')
+      .field('name', 'Test')
+      .field('owner', 'u1')
+      .field('participantLimit', '10')
+      .attach('fixture', Buffer.from(JSON.stringify(fixture)), 'fixture.json');
+
+    expect(res.status).toBe(201);
+    expect(Penca).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'Test',
+      owner: 'u1',
+      participantLimit: 10
+    }));
+    expect(Match.insertMany).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- allow admins to create pencas via POST `/admin/pencas`
- optional fixture JSON uploads populate matches
- support setting owner and participant limits
- add tests for the new endpoint

## Testing
- `./scripts/setup-tests.sh` *(fails: 403 Forbidden - GET https://registry.npmjs.org/connect-mongo)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c55f347c083258a1453a84bd6487c