### PR TITLE
Limit user penca joins

### DIFF
--- a/routes/penca.js
+++ b/routes/penca.js
@@ -48,7 +48,12 @@ router.get('/:pencaId', isAuthenticated, async (req, res) => {
 router.post('/join', isAuthenticated, async (req, res) => {
   const { code } = req.body;
   const userId = req.session.user._id;
+  const joined = req.session.user.pencas || [];
   try {
+    if (joined.length >= 3) {
+      return res.status(400).json({ error: 'You have reached the maximum number of pencas you can join' });
+    }
+
     const penca = await Penca.findOne({ code });
     if (!penca) return res.status(404).json({ error: 'Penca not found' });
 


### PR DESCRIPTION
## Summary
- restrict penca join requests when a user has too many groups

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c55f472c88325b175d25b6405a55e