### PR TITLE
Filter ranking per penca

### DIFF
--- a/routes/ranking.js
+++ b/routes/ranking.js
@@ -4,11 +4,21 @@ const User = require('../models/User');
 const Prediction = require('../models/Prediction');
 const Match = require('../models/Match');
 const Score = require('../models/Score');
+const Penca = require('../models/Penca');
 const { DEFAULT_COMPETITION } = require('../config');
 
 // Función para calcular los puntajes
 async function calculateScores(pencaId) {
-    const users = await User.find({ valid: true });
+    let userFilter = { valid: true };
+    if (pencaId) {
+        const penca = await Penca.findById(pencaId).select('participants');
+        if (!penca) {
+            return [];
+        }
+        userFilter._id = { $in: penca.participants };
+    }
+
+    const users = await User.find(userFilter);
     const matches = await Match.find();
     const filter = pencaId ? { pencaId } : {};
     const predictions = await Prediction.find(filter);

--- a/tests/ranking.test.js
+++ b/tests/ranking.test.js
@@ -4,10 +4,12 @@ const express = require('express');
 jest.mock('../models/User', () => ({ find: jest.fn() }));
 jest.mock('../models/Match', () => ({ find: jest.fn() }));
 jest.mock('../models/Prediction', () => ({ find: jest.fn() }));
+jest.mock('../models/Penca', () => ({ findById: jest.fn() }));
 
 const User = require('../models/User');
 const Match = require('../models/Match');
 const Prediction = require('../models/Prediction');
+const Penca = require('../models/Penca');
 const rankingRouter = require('../routes/ranking');
 
 describe('GET /ranking', () => {
@@ -25,5 +27,26 @@ describe('GET /ranking', () => {
     expect(res.status).toBe(200);
     expect(Array.isArray(res.body)).toBe(true);
     expect(res.body[0]).toHaveProperty('score');
+  });
+
+  it('filters scores by penca participants', async () => {
+    User.find.mockResolvedValue([
+      { _id: 'u1', username: 'u1' },
+      { _id: 'u2', username: 'u2' }
+    ]);
+    Match.find.mockResolvedValue([{ _id: 'm1', result1: 1, result2: 0 }]);
+    Prediction.find.mockResolvedValue([
+      { pencaId: 'p1', userId: 'u1', matchId: 'm1', result1: 1, result2: 0 },
+      { pencaId: 'p1', userId: 'u2', matchId: 'm1', result1: 1, result2: 0 }
+    ]);
+    Penca.findById.mockResolvedValue({ participants: ['u1'] });
+
+    const app = express();
+    app.use('/ranking', rankingRouter);
+
+    const res = await request(app).get('/ranking').query({ pencaId: 'p1' });
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBe(1);
+    expect(res.body[0].userId).toBe('u1');
   });
 });


### PR DESCRIPTION
## Summary
- restrict ranking calculations to penca participants
- test ranking endpoint for penca specific ranking

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c55f50b308325be0fe312a84c000f