### PR TITLE
Update env block with SESSION_SECRET note

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ proyecto con la URL de tu base de datos MongoDB y las credenciales del administr
 MONGODB_URI=mongodb://<usuario>:<password>@<host>/<basedatos>
 DEFAULT_ADMIN_USERNAME=<usuario_admin>
 DEFAULT_ADMIN_PASSWORD=<contraseña_admin>
-SESSION_SECRET=<cadena_secreta>
+SESSION_SECRET=<tu_clave>
 # Opcionalmente puedes definir el puerto de la app
 PORT=3000
 ```
+Si no defines `SESSION_SECRET`, el servidor se cerrará al iniciarse.
 
 3. Inicia el servidor en modo desarrollo con **nodemon**:
 


### PR DESCRIPTION
## Summary
- update `.env` example with `SESSION_SECRET=<tu_clave>`
- document that the server exits if `SESSION_SECRET` isn't provided

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5cd234c883258c79a2ea7bffb0e7