### PR TITLE
Add debug flag for logs

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -1,4 +1,10 @@
 document.addEventListener('DOMContentLoaded', async function() {
+    const DEBUG = window.DEBUG === true;
+    function debugLog(...args) {
+        if (DEBUG) {
+            console.log(...args);
+        }
+    }
     var elems = document.querySelectorAll('.tabs');
     var instances = M.Tabs.init(elems);
 
@@ -10,8 +16,8 @@ document.addEventListener('DOMContentLoaded', async function() {
     const username = document.querySelector('body').getAttribute('data-username');
 
     // Mostrar el rol y el nombre de usuario
-    console.log('User Role:', userRole);
-    console.log('Username:', username);
+    debugLog('User Role:', userRole);
+    debugLog('Username:', username);
 
     let matches = []; // Definir la variable matches en el contexto adecuado
 
@@ -26,9 +32,9 @@ document.addEventListener('DOMContentLoaded', async function() {
         const now = new Date();
         const timeDifference = (matchDateTime - now) / 60000; // Diferencia en minutos
 
-        console.log(`currentTime (client): ${now}`);
-        console.log(`matchDateTime (client): ${matchDateTime}`);
-        console.log(`timeDifference (client): ${timeDifference} minutos`);
+        debugLog(`currentTime (client): ${now}`);
+        debugLog(`matchDateTime (client): ${matchDateTime}`);
+        debugLog(`timeDifference (client): ${timeDifference} minutos`);
 
         return timeDifference < 30;
     };
@@ -45,7 +51,7 @@ document.addEventListener('DOMContentLoaded', async function() {
             return dateA - dateB;
         });
 
-        console.log('Matches fetched and sorted successfully');
+        debugLog('Matches fetched and sorted successfully');
 
         const predictionsResponse = await fetch('/predictions');
         const predictions = await predictionsResponse.json();
@@ -169,8 +175,8 @@ document.addEventListener('DOMContentLoaded', async function() {
 
                 // Verificar si faltan menos de 30 minutos para el partido
                 const match = matches.find(m => m._id.toString() === data.matchId);
-                console.log('match.date:', match.date); // Agregar esta línea
-                console.log('match.time:', match.time); // Agregar esta línea
+                debugLog('match.date:', match.date); // Agregar esta línea
+                debugLog('match.time:', match.time); // Agregar esta línea
 
                 if (isLessThan30MinutesToMatch(match.date, match.time)) {
                     M.toast({html: 'No se puede enviar predicción dentro de los 30 minutos previos al partido', classes: 'red'});
@@ -187,7 +193,7 @@ document.addEventListener('DOMContentLoaded', async function() {
                     });
                     const result = await response.json();
                     if (response.ok) {
-                        console.log('Predicción enviada exitosamente');
+                        debugLog('Predicción enviada exitosamente');
                         M.toast({html: 'Predicción actualizada correctamente!', classes: 'green'});
                         const matchCard = form.closest('.card');
                         if (matchCard) {
@@ -228,7 +234,7 @@ document.addEventListener('DOMContentLoaded', async function() {
                         });
                         const result = await response.json();
                         if (response.ok) {
-                            console.log('Resultado enviado exitosamente');
+                            debugLog('Resultado enviado exitosamente');
                             M.toast({html: 'Resultado actualizado correctamente!', classes: 'green'});
                             // Recalcular puntaje de todos los usuarios
                             //await fetch('/ranking/recalculate', { method: 'POST' });

--- a/routes/predictions.js
+++ b/routes/predictions.js
@@ -4,6 +4,13 @@ const Prediction = require('../models/Prediction');
 const Match = require('../models/Match'); // Importar el modelo de partidos
 const Penca = require('../models/Penca');
 
+const DEBUG = process.env.DEBUG === 'true';
+function debugLog(...args) {
+    if (DEBUG) {
+        console.log(...args);
+    }
+}
+
 router.get('/', async (req, res) => {
     try {
         const predictions = await Prediction.find();
@@ -40,12 +47,12 @@ router.post('/', async (req, res) => {
         const currentTime = new Date();
         const matchDateTime = new Date(`${match.date}T${match.time}:00`); // Combinar fecha y hora
 
-        console.log(`currentTime: ${currentTime}`);
-        console.log(`matchDateTime: ${matchDateTime}`);
+        debugLog(`currentTime: ${currentTime}`);
+        debugLog(`matchDateTime: ${matchDateTime}`);
 
         const timeDifference = (matchDateTime - currentTime) / 60000; // Diferencia en minutos
 
-        console.log(`timeDifference: ${timeDifference} minutos`);
+        debugLog(`timeDifference: ${timeDifference} minutos`);
 
         if (timeDifference < 30) {
             return res.status(400).json({ error: 'No se puede enviar la predicción dentro de los 30 minutos previos al inicio del partido' });

--- a/updateschema.js
+++ b/updateschema.js
@@ -4,6 +4,13 @@ const dotenv = require('dotenv');
 
 dotenv.config();
 
+const DEBUG = process.env.DEBUG === 'true';
+function debugLog(...args) {
+    if (DEBUG) {
+        console.log(...args);
+    }
+}
+
 const uri = process.env.MONGODB_URI;
 if (!uri) {
     console.error('MONGODB_URI environment variable not provided. Exiting...');
@@ -31,10 +38,10 @@ async function createSchema() {
         if (!adminUser) {
             const hashedPassword = await bcrypt.hash(adminPassword, 10);
             await usersCollection.insertOne({ username: adminUsername, password: hashedPassword, role: 'admin' });
-            console.log('Admin user created');
+            debugLog('Admin user created');
         }
 
-        console.log("Schema created successfully");
+        debugLog("Schema created successfully");
     } catch (error) {
         console.error("Error creating schema:", error);
     } finally {

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -103,6 +103,7 @@
     </div>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+    <script>window.DEBUG = <%= debug ? 'true' : 'false' %>;</script>
     <script src="/js/dashboard.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- wrap server console output behind a debug flag
- do the same for admin scripts and prediction routes
- expose `DEBUG` value to the dashboard client
- provide a browser-side debug helper to gate logs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5cd4c8508325a95094254512edf0