### PR TITLE
Remove automatic match loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ definidas en tu archivo `.env`.
 - **routes/** – rutas de la aplicación: administración, partidos, predicciones, ranking y pencas.
 - **public/** – archivos estáticos (CSS, imágenes, scripts de cliente, uploads).
 - **views/** – plantillas EJS para las vistas HTML.
-- **matches.json** – datos de los partidos utilizados para inicializar la base.
+- **matches.json** – datos de ejemplo de los partidos que pueden cargarse desde las rutas de administración.
 - **updateschema.js** – script auxiliar para crear o actualizar esquemas en MongoDB.
+
+Los partidos ya no se insertan automáticamente al iniciar la aplicación. Debes cargarlos manualmente desde el panel de administración.
 
 El esquema `Penca` permite organizar competiciones privadas. Los usuarios se unen con un código y el propietario decide aprobar o eliminar participantes.
 

--- a/main.js
+++ b/main.js
@@ -138,9 +138,7 @@ async function initializeDatabase() {
         // Prepopular partidos si la colección está vacía
         const matchCount = await Match.countDocuments();
         if (matchCount === 0) {
-            const matches = require('./matches.json');
-            await Match.insertMany(matches);
-            debugLog('Partidos prepopulados.');
+            debugLog('No hay partidos en la base de datos. Los partidos deberán cargarse desde las rutas de administración.');
         }
     } catch (error) {
         console.error('Error al inicializar la base de datos:', error);


### PR DESCRIPTION
## Summary
- remove the block that auto-imports `matches.json` in `initializeDatabase`
- log a message telling admins to load matches via admin routes
- update docs to explain that matches must be manually loaded

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c658bd4a48325ba6395f79b1016d9