### PR TITLE
Add competition management routes and UI

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -137,8 +137,8 @@ router.post('/pencas', isAuthenticated, isAdmin, jsonUpload.single('fixture'), a
 
 router.get('/competitions', isAuthenticated, isAdmin, async (req, res) => {
     try {
-        const competitions = await Competition.find();
-        res.json(competitions);
+        const competitions = await Competition.find().sort('name');
+        res.status(200).json(competitions);
     } catch (error) {
         console.error('Error listing competitions:', error);
         res.status(500).json({ error: 'Internal server error' });
@@ -159,7 +159,7 @@ router.post('/competitions', isAuthenticated, isAdmin, jsonUpload.single('fixtur
             const matchesData = JSON.parse(req.file.buffer.toString());
             matchesData.forEach(m => { if (!m.competition) m.competition = name; });
             await Match.insertMany(matchesData);
-        } else if (useApi === 'true') {
+        } else if (String(useApi) === 'true') {
             // TODO: Integrate API-Football fixture loading
         }
 

--- a/tests/admin.test.js
+++ b/tests/admin.test.js
@@ -9,10 +9,12 @@ jest.mock('../models/Penca', () => {
 });
 
 jest.mock('../models/Competition', () => {
-  return jest.fn(function (data) {
+  const CompetitionMock = jest.fn(function (data) {
     Object.assign(this, data);
     this.save = jest.fn().mockResolvedValue(this);
   });
+  CompetitionMock.find = jest.fn();
+  return CompetitionMock;
 });
 
 jest.mock('../models/Match', () => ({
@@ -86,5 +88,17 @@ describe('Admin competition creation', () => {
     expect(res.status).toBe(201);
     expect(Competition).toHaveBeenCalledWith(expect.objectContaining({ name: 'Copa Test' }));
     expect(Match.insertMany).toHaveBeenCalled();
+  });
+
+  it('lists competitions', async () => {
+    Competition.find.mockResolvedValue([{ name: 'Copa Test' }]);
+
+    const app = express();
+    app.use('/admin', adminRouter);
+
+    const res = await request(app).get('/admin/competitions');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ name: 'Copa Test' }]);
   });
 });

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -137,6 +137,8 @@
                     </div>
                     <button class="btn waves-effect waves-light" type="submit">Crear</button>
                 </form>
+                <h4>Competencias existentes</h4>
+                <ul id="competitionList" class="collection"></ul>
             </div>
         </div>
         <div id="settings" class="col s12">
@@ -276,6 +278,7 @@
                         if (response.ok) {
                             M.toast({html: 'Competencia creada', classes: 'green'});
                             this.reset();
+                            loadCompetitions();
                         } else {
                             const result = await response.json();
                             console.error('Error:', result.error);
@@ -287,6 +290,22 @@
                     }
                 });
             }
+
+            function loadCompetitions() {
+                const list = document.getElementById('competitionList');
+                if (!list) return;
+                fetch('/admin/competitions').then(r => r.json()).then(data => {
+                    list.innerHTML = '';
+                    data.forEach(c => {
+                        const li = document.createElement('li');
+                        li.className = 'collection-item';
+                        li.textContent = c.name;
+                        list.appendChild(li);
+                    });
+                });
+            }
+
+            loadCompetitions();
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- enhance `/admin/competitions` GET to sort results
- support boolean flag for `useApi` in POST
- list existing competitions in the admin page
- extend admin tests with competition listing case

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c6875b0148325a627c594e162e88b