### PR TITLE
Add penca selection collapsible and include pencaId in prediction forms

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -11,23 +11,28 @@ document.addEventListener('DOMContentLoaded', async function() {
     // Inicializar el dropdown
     var dropdownElems = document.querySelectorAll('.dropdown-trigger');
     var dropdownInstances = M.Dropdown.init(dropdownElems, { constrainWidth: false, coverTrigger: false });
-    var selectElems = document.querySelectorAll('select');
-    var selectInstances = M.FormSelect.init(selectElems);
+    var collapsibleElems = document.querySelectorAll('.collapsible');
+    var collapsibleInstances = M.Collapsible.init(collapsibleElems);
 
-    var pencaSelect = document.getElementById('penca-select');
-    var selectedPencaId = pencaSelect ? pencaSelect.value : null;
-    if (pencaSelect) {
+    var pencaItems = document.querySelectorAll('#penca-collapsible li');
+    var selectedPencaId = null;
+    if (pencaItems.length) {
         var storedPenca = localStorage.getItem('selectedPenca');
         if (storedPenca) {
-            pencaSelect.value = storedPenca;
-            M.FormSelect.getInstance(pencaSelect).destroy();
-            M.FormSelect.init(pencaSelect);
             selectedPencaId = storedPenca;
-        }
-        pencaSelect.addEventListener('change', () => {
-            selectedPencaId = pencaSelect.value;
+        } else {
+            selectedPencaId = pencaItems[0].dataset.id;
             localStorage.setItem('selectedPenca', selectedPencaId);
-            window.location.reload();
+        }
+        pencaItems.forEach((item) => {
+            if (item.dataset.id === selectedPencaId) {
+                item.classList.add('active');
+            }
+            item.querySelector('.collapsible-header').addEventListener('click', () => {
+                selectedPencaId = item.dataset.id;
+                localStorage.setItem('selectedPenca', selectedPencaId);
+                window.location.reload();
+            });
         });
     }
 

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -33,16 +33,14 @@
     <main>
         <div class="container">
             <% if (pencas && pencas.length) { %>
-            <div class="row">
-                <div class="input-field col s12 m6">
-                    <select id="penca-select">
-                        <% pencas.forEach(function(p) { %>
-                            <option value="<%= p._id %>"><%= p.name %></option>
-                        <% }); %>
-                    </select>
-                    <label>Seleccionar Penca</label>
-                </div>
-            </div>
+            <ul id="penca-collapsible" class="collapsible">
+                <% pencas.forEach(function(p) { %>
+                <li data-id="<%= p._id %>">
+                    <div class="collapsible-header"><i class="material-icons">group</i><%= p.name %></div>
+                    <div class="collapsible-body"><span>Seleccionar esta penca</span></div>
+                </li>
+                <% }); %>
+            </ul>
             <% } %>
             <ul class="tabs">
                 <li class="tab col s2"><a href="#fixture" class="<%= user.role === 'admin' ? 'active' : '' %>">Fixture</a></li>


### PR DESCRIPTION
## Summary
- show a collapsible with the user's pencas on the dashboard
- store penca selection in localStorage
- ensure each prediction form includes the selected pencaId

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c6874ff248325bc28878307b776a2