### PR TITLE
Render pencas as collapsible items

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -1,320 +1,210 @@
 document.addEventListener('DOMContentLoaded', async function() {
     const DEBUG = window.DEBUG === true;
-    function debugLog(...args) {
-        if (DEBUG) {
-            console.log(...args);
-        }
-    }
-    var elems = document.querySelectorAll('.tabs');
-    var instances = M.Tabs.init(elems);
+    function debugLog(...args) { if (DEBUG) console.log(...args); }
 
-    // Inicializar el dropdown
-    var dropdownElems = document.querySelectorAll('.dropdown-trigger');
-    var dropdownInstances = M.Dropdown.init(dropdownElems, { constrainWidth: false, coverTrigger: false });
-    var selectElems = document.querySelectorAll('select');
-    var selectInstances = M.FormSelect.init(selectElems);
+    const pencas = window.PENCAS || [];
+    const userRole = document.body.getAttribute('data-role');
+    const username = document.body.getAttribute('data-username');
 
-    var pencaSelect = document.getElementById('penca-select');
-    var selectedPencaId = pencaSelect ? pencaSelect.value : null;
-    if (pencaSelect) {
-        var storedPenca = localStorage.getItem('selectedPenca');
-        if (storedPenca) {
-            pencaSelect.value = storedPenca;
-            M.FormSelect.getInstance(pencaSelect).destroy();
-            M.FormSelect.init(pencaSelect);
-            selectedPencaId = storedPenca;
-        }
-        pencaSelect.addEventListener('change', () => {
-            selectedPencaId = pencaSelect.value;
-            localStorage.setItem('selectedPenca', selectedPencaId);
-            window.location.reload();
-        });
-    }
+    // Inicializar Materialize
+    M.Dropdown.init(document.querySelectorAll('.dropdown-trigger'), { constrainWidth: false, coverTrigger: false });
+    M.Collapsible.init(document.querySelectorAll('.collapsible'));
 
-    const userRole = document.querySelector('body').getAttribute('data-role');
-    const username = document.querySelector('body').getAttribute('data-username');
-
-    // Mostrar el rol y el nombre de usuario
-    debugLog('User Role:', userRole);
-    debugLog('Username:', username);
-
-    let matches = []; // Definir la variable matches en el contexto adecuado
-
-    // Función para normalizar los nombres de los equipos eliminando tildes y convirtiendo a minúsculas
-    const normalizeName = (name) => {
-        return name.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, "");
-    };
-
-    // Función para verificar si faltan menos de 30 minutos para el partido
+    const normalizeName = name => name.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
     const isLessThan30MinutesToMatch = (matchDate, matchTime) => {
-        const matchDateTime = new Date(`${matchDate}T${matchTime}:00`); // Combinar fecha y hora
+        const matchDateTime = new Date(`${matchDate}T${matchTime}:00`);
         const now = new Date();
-        const timeDifference = (matchDateTime - now) / 60000; // Diferencia en minutos
-
-        debugLog(`currentTime (client): ${now}`);
-        debugLog(`matchDateTime (client): ${matchDateTime}`);
-        debugLog(`timeDifference (client): ${timeDifference} minutos`);
-
-        return timeDifference < 30;
+        return (matchDateTime - now) / 60000 < 30;
     };
 
-    // Cargar los partidos
     try {
-        const matchesResponse = await fetch('/matches');
-        matches = await matchesResponse.json();
+        const matches = await fetch('/matches').then(r => r.json());
+        matches.sort((a,b) => new Date(`${a.date}T${a.time}:00`) - new Date(`${b.date}T${b.time}:00`));
+        const allPreds = await fetch('/predictions').then(r => r.json());
 
-        // Ordenar los partidos por fecha y hora
-        matches.sort((a, b) => {
-            const dateA = new Date(`${a.date}T${a.time}:00`);
-            const dateB = new Date(`${b.date}T${b.time}:00`);
-            return dateA - dateB;
-        });
+        for (const penca of pencas) {
+            const userPreds = allPreds.filter(p => p.username === username && p.pencaId === penca._id);
+            const matchesList = document.getElementById(`matches-list-${penca._id}`);
+            const predsList = document.getElementById(`predictions-list-${penca._id}`);
+            matchesList.innerHTML = '';
+            predsList.innerHTML = '';
 
-        debugLog('Matches fetched and sorted successfully');
+            matches.forEach(match => {
+                const team1Flag = normalizeName(match.team1);
+                const team2Flag = normalizeName(match.team2);
+                const userPrediction = userPreds.find(pr => pr.matchId.toString() === match._id.toString());
 
-        const predictionsResponse = await fetch('/predictions');
-        const predictions = await predictionsResponse.json();
-        const userPredictions = predictions.filter(prediction => prediction.username === username && (!selectedPencaId || prediction.pencaId === selectedPencaId));
-
-        const matchesList = document.getElementById('matches-list');
-        const predictionsList = document.getElementById('predictions-list');
-        matchesList.innerHTML = ''; // Limpiar cualquier contenido previo
-        predictionsList.innerHTML = ''; // Limpiar cualquier contenido previo
-
-        matches.forEach(match => {
-            const team1Flag = normalizeName(match.team1); // Normalizar el nombre del equipo
-            const team2Flag = normalizeName(match.team2); // Normalizar el nombre del equipo
-            const userPrediction = userPredictions.find(prediction => prediction.matchId.toString() === match._id.toString());
-
-            // Crear tarjeta de fixture
-            const matchDiv = document.createElement('div');
-            matchDiv.className = 'col s12 m6';
-            matchDiv.innerHTML = `
-                <div class="card match-card ${match.result1 !== undefined && match.result2 !== undefined ? 'saved' : ''}">
-                    <div class="card-content">
-                        <div class="row">
-                            <div class="col s10">
-                                <div class="date-time">
-                                    <div class="info">
-                                        <img src="/images/cal.png" alt="Fecha" class="small-icon">
-                                        <span>${match.date}</span>
-                                    </div>
-                                    <div class="info">
-                                        <img src="/images/clock.png" alt="Hora" class="small-icon">
-                                        <span>${match.time}</span>
+                const mDiv = document.createElement('div');
+                mDiv.className = 'col s12 m6';
+                mDiv.innerHTML = `
+                    <div class="card match-card ${match.result1 !== undefined && match.result2 !== undefined ? 'saved' : ''}">
+                        <div class="card-content">
+                            <div class="row">
+                                <div class="col s10">
+                                    <div class="date-time">
+                                        <div class="info"><img src="/images/cal.png" class="small-icon" alt="Fecha"><span>${match.date}</span></div>
+                                        <div class="info"><img src="/images/clock.png" class="small-icon" alt="Hora"><span>${match.time}</span></div>
                                     </div>
                                 </div>
                             </div>
-                        </div>
-                        <div class="match-header">
-                            <div class="team">
-                                <img src="/images/${team1Flag}.png" alt="${match.team1}" class="circle responsive-img">
-                                <span class="team-name">${match.team1}</span>
+                            <div class="match-header">
+                                <div class="team"><img src="/images/${team1Flag}.png" alt="${match.team1}" class="circle responsive-img"><span class="team-name">${match.team1}</span></div>
+                                <span class="vs">vs</span>
+                                <div class="team"><img src="/images/${team2Flag}.png" alt="${match.team2}" class="circle responsive-img"><span class="team-name">${match.team2}</span></div>
                             </div>
-                            <span class="vs">vs</span>
-                            <div class="team">
-                                <img src="/images/${team2Flag}.png" alt="${match.team2}" class="circle responsive-img">
-                                <span class="team-name">${match.team2}</span>
-                            </div>
-                        </div>
-                        <div class="match-details">
-                            ${userRole === 'admin' ? `
-                            <form id="matchForm-${match._id}" method="POST" action="/matches/${match._id}">
-                                <div class="input-field inline">
-                                    <input type="number" class="result-input" name="result1" value="${match.result1 || ''}" required>
-                                    <span>-</span>
-                                    <input type="number" class="result-input" name="result2" value="${match.result2 || ''}" required>
-                                </div>
-                                <button class="btn waves-effect waves-light blue darken-3" type="submit">Guardar Resultado</button>
-                            </form>` : `
-                            <p>Resultado: ${match.result1 !== undefined ? match.result1 : '-'} - ${match.result2 !== undefined ? match.result2 : '-'}</p>`}
-                        </div>
-                    </div>
-                </div>
-            `;
-            matchesList.appendChild(matchDiv);
-
-            // Crear tarjeta de predicciones
-            const predictionDiv = document.createElement('div');
-            predictionDiv.className = 'col s12 m6';
-            predictionDiv.innerHTML = `
-                <div class="card match-card ${userPrediction ? 'saved' : ''}">
-                    <div class="card-content">
-                        <div class="row">
-                            <div class="col s10">
-                                <div class="date-time">
-                                    <div class="info">
-                                        <img src="/images/cal.png" alt="Fecha" class="small-icon">
-                                        <span>${match.date}</span>
+                            <div class="match-details">
+                                ${userRole === 'admin' ? `
+                                <form id="matchForm-${penca._id}-${match._id}" method="POST" action="/matches/${match._id}">
+                                    <div class="input-field inline">
+                                        <input type="number" class="result-input" name="result1" value="${match.result1 || ''}" required>
+                                        <span>-</span>
+                                        <input type="number" class="result-input" name="result2" value="${match.result2 || ''}" required>
                                     </div>
-                                    <div class="info">
-                                        <img src="/images/clock.png" alt="Hora" class="small-icon">
-                                        <span>${match.time}</span>
+                                    <button class="btn waves-effect waves-light blue darken-3" type="submit">Guardar Resultado</button>
+                                </form>` : `
+                                <p>Resultado: ${match.result1 !== undefined ? match.result1 : '-'} - ${match.result2 !== undefined ? match.result2 : '-'}</p>`}
+                            </div>
+                        </div>
+                    </div>`;
+                matchesList.appendChild(mDiv);
+
+                const pDiv = document.createElement('div');
+                pDiv.className = 'col s12 m6';
+                pDiv.innerHTML = `
+                    <div class="card match-card ${userPrediction ? 'saved' : ''}">
+                        <div class="card-content">
+                            <div class="row">
+                                <div class="col s10">
+                                    <div class="date-time">
+                                        <div class="info"><img src="/images/cal.png" class="small-icon" alt="Fecha"><span>${match.date}</span></div>
+                                        <div class="info"><img src="/images/clock.png" class="small-icon" alt="Hora"><span>${match.time}</span></div>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col s2">
-                                ${userPrediction ? `<img src="/images/tick.png" alt="Predicción guardada" class="tick-icon right">` : ''}
-                            </div>
-                        </div>
-                        <div class="match-header">
-                            <div class="team">
-                                <img src="/images/${team1Flag}.png" alt="${match.team1}" class="circle responsive-img">
-                                <span class="team-name">${match.team1}</span>
-                            </div>
-                            <span class="vs">vs</span>
-                            <div class="team">
-                                <img src="/images/${team2Flag}.png" alt="${match.team2}" class="circle responsive-img">
-                                <span class="team-name">${match.team2}</span>
-                            </div>
-                        </div>
-                        <div class="match-details">
-                            <form id="predictionForm-${match._id}" method="POST" action="/predictions">
-                                <input type="hidden" name="matchId" value="${match._id}">
-                                <input type="hidden" name="pencaId" value="${selectedPencaId}">
-                                <div class="input-field inline">
-                                    <input type="number" class="result-input" name="result1" value="${userPrediction ? userPrediction.result1 : ''}" required>
-                                    <span>-</span>
-                                    <input type="number" class="result-input" name="result2" value="${userPrediction ? userPrediction.result2 : ''}" required>
+                                <div class="col s2">
+                                    ${userPrediction ? `<img src="/images/tick.png" alt="Predicción guardada" class="tick-icon right">` : ''}
                                 </div>
-                                <button class="btn waves-effect waves-light blue darken-3" type="submit">Enviar Predicción</button>
-                            </form>
+                            </div>
+                            <div class="match-header">
+                                <div class="team"><img src="/images/${team1Flag}.png" alt="${match.team1}" class="circle responsive-img"><span class="team-name">${match.team1}</span></div>
+                                <span class="vs">vs</span>
+                                <div class="team"><img src="/images/${team2Flag}.png" alt="${match.team2}" class="circle responsive-img"><span class="team-name">${match.team2}</span></div>
+                            </div>
+                            <div class="match-details">
+                                <form id="predictionForm-${penca._id}-${match._id}" method="POST" action="/predictions">
+                                    <input type="hidden" name="matchId" value="${match._id}">
+                                    <input type="hidden" name="pencaId" value="${penca._id}">
+                                    <div class="input-field inline">
+                                        <input type="number" class="result-input" name="result1" value="${userPrediction ? userPrediction.result1 : ''}" required>
+                                        <span>-</span>
+                                        <input type="number" class="result-input" name="result2" value="${userPrediction ? userPrediction.result2 : ''}" required>
+                                    </div>
+                                    <button class="btn waves-effect waves-light blue darken-3" type="submit">Enviar Predicción</button>
+                                </form>
+                            </div>
                         </div>
-                    </div>
-                </div>
-            `;
-            predictionsList.appendChild(predictionDiv);
-        });
+                    </div>`;
+                predsList.appendChild(pDiv);
+            });
+        }
 
-        // Añadir eventos de envío para los formularios de predicción
         document.querySelectorAll('form[id^="predictionForm-"]').forEach(form => {
-            form.addEventListener('submit', async (e) => {
+            form.addEventListener('submit', async e => {
                 e.preventDefault();
-                const formData = new FormData(form);
-                const data = Object.fromEntries(formData.entries());
-
-                // Verificar si faltan menos de 30 minutos para el partido
+                const data = Object.fromEntries(new FormData(form).entries());
                 const match = matches.find(m => m._id.toString() === data.matchId);
-                debugLog('match.date:', match.date); // Agregar esta línea
-                debugLog('match.time:', match.time); // Agregar esta línea
-
                 if (isLessThan30MinutesToMatch(match.date, match.time)) {
                     M.toast({html: 'No se puede enviar predicción dentro de los 30 minutos previos al partido', classes: 'red'});
                     return;
                 }
-
                 try {
-                    const response = await fetch(form.action, {
+                    const resp = await fetch(form.action, {
                         method: 'POST',
-                        headers: {
-                            'Content-Type': 'application/json'
-                        },
+                        headers: {'Content-Type': 'application/json'},
                         body: JSON.stringify(data)
                     });
-                    const result = await response.json();
-                    if (response.ok) {
-                        debugLog('Predicción enviada exitosamente');
+                    const result = await resp.json();
+                    if (resp.ok) {
                         M.toast({html: 'Predicción actualizada correctamente!', classes: 'green'});
-                        const matchCard = form.closest('.card');
-                        if (matchCard) {
-                            matchCard.classList.add('saved');
-                            if (!matchCard.querySelector('.tick-icon')) {
-                                const tickIcon = document.createElement('img');
-                                tickIcon.src = '/images/tick.png';
-                                tickIcon.alt = 'Predicción guardada';
-                                tickIcon.className = 'tick-icon right';
-                                matchCard.querySelector('.row').appendChild(tickIcon);
+                        const card = form.closest('.card');
+                        if (card) {
+                            card.classList.add('saved');
+                            if (!card.querySelector('.tick-icon')) {
+                                const tick = document.createElement('img');
+                                tick.src = '/images/tick.png';
+                                tick.alt = 'Predicción guardada';
+                                tick.className = 'tick-icon right';
+                                card.querySelector('.row').appendChild(tick);
                             }
                         }
                     } else {
                         console.error('Error:', result.error);
                         M.toast({html: 'Error al actualizar la predicción', classes: 'red'});
                     }
-                } catch (error) {
-                    console.error('Error al enviar la predicción:', error);
+                } catch (err) {
+                    console.error('Error al enviar la predicción:', err);
                     M.toast({html: 'Error al enviar la predicción', classes: 'red'});
                 }
             });
         });
 
-        // Añadir eventos de envío para los formularios de resultados (solo para admin)
         if (userRole === 'admin') {
             document.querySelectorAll('form[id^="matchForm-"]').forEach(form => {
-                form.addEventListener('submit', async (e) => {
+                form.addEventListener('submit', async e => {
                     e.preventDefault();
-                    const formData = new FormData(form);
-                    const data = Object.fromEntries(formData.entries());
+                    const data = Object.fromEntries(new FormData(form).entries());
                     try {
-                        const response = await fetch(form.action, {
+                        const resp = await fetch(form.action, {
                             method: 'POST',
-                            headers: {
-                                'Content-Type': 'application/json'
-                            },
+                            headers: {'Content-Type': 'application/json'},
                             body: JSON.stringify(data)
                         });
-                        const result = await response.json();
-                        if (response.ok) {
-                            debugLog('Resultado enviado exitosamente');
+                        const result = await resp.json();
+                        if (resp.ok) {
                             M.toast({html: 'Resultado actualizado correctamente!', classes: 'green'});
-                            // Recalcular puntaje de todos los usuarios
-                            //await fetch('/ranking/recalculate', { method: 'POST' });
                         } else {
                             console.error('Error:', result.error);
                             M.toast({html: 'Error al actualizar el resultado', classes: 'red'});
                         }
-                    } catch (error) {
-                        console.error('Error al enviar el resultado:', error);
+                    } catch (err) {
+                        console.error('Error al enviar el resultado:', err);
                         M.toast({html: 'Error al enviar el resultado', classes: 'red'});
                     }
                 });
             });
         }
-
-    } catch (error) {
-        console.error('Error al cargar los partidos:', error);
+    } catch (err) {
+        console.error('Error al cargar los partidos:', err);
     }
 
-    // Cargar el ranking
-    try {
-        const rankingUrl = selectedPencaId ? `/ranking?pencaId=${selectedPencaId}` : '/ranking';
-        const rankingResponse = await fetch(rankingUrl);
-        if (!rankingResponse.ok) {
-            throw new Error(`HTTP error! status: ${rankingResponse.status}`);
+    // Cargar ranking por penca
+    for (const penca of pencas) {
+        try {
+            const rankingResponse = await fetch(`/ranking?pencaId=${penca._id}`);
+            if (!rankingResponse.ok) throw new Error(rankingResponse.status);
+            const ranking = await rankingResponse.json();
+            ranking.sort((a,b) => b.score - a.score);
+            const highest = ranking[0]?.score;
+            const list = document.getElementById(`ranking-list-${penca._id}`);
+            list.innerHTML = '';
+            const col = document.createElement('ul');
+            col.className = 'collection';
+            col.innerHTML = ranking.map(u => `
+                <li class="collection-item avatar ${u.score === highest ? 'highlight-first' : ''}">
+                    <img src="${u.avatar ? '/avatar/' + u.username : '/images/avatar.webp'}" alt="${u.username}" class="circle">
+                    <span class="title">${u.username}</span>
+                    <p>Puntaje: ${u.score}</p>
+                </li>
+            `).join('');
+            list.appendChild(col);
+        } catch(err) {
+            console.error('Error al cargar el ranking:', err);
         }
-        let ranking = await rankingResponse.json();
-        const rankingList = document.getElementById('ranking-list');
-        rankingList.innerHTML = ''; // Limpiar cualquier contenido previo
-
-        // Ordenar el ranking por puntaje en orden descendente
-        ranking.sort((a, b) => b.score - a.score);
-
-        // Encontrar el puntaje más alto
-        const highestScore = ranking[0]?.score;
-
-        const collection = document.createElement('ul');
-        collection.className = 'collection';
-
-        collection.innerHTML = ranking.map(user => `
-            <li class="collection-item avatar ${user.score === highestScore ? 'highlight-first' : ''}">
-                <img src="${user.avatar ? '/avatar/' + user.username : '/images/avatar.webp'}" alt="${user.username}" class="circle">
-                <span class="title">${user.username}</span>
-                <p>Puntaje: ${user.score}</p>
-            </li>
-        `).join('');
-
-        rankingList.appendChild(collection);
-    } catch (error) {
-        console.error('Error al cargar el ranking:', error.message);
     }
 
-    // Manejar el cierre de sesión
     document.getElementById('logout-button').addEventListener('click', async () => {
         try {
             const response = await fetch('/logout', { method: 'POST' });
-            if (response.ok) {
-                window.location.href = '/';
-            } else {
-                console.error('Error al cerrar sesión');
+            if (response.ok) { window.location.href = '/'; } else {
                 M.toast({html: 'Error al cerrar sesión', classes: 'red'});
             }
         } catch (error) {
@@ -323,22 +213,18 @@ document.addEventListener('DOMContentLoaded', async function() {
         }
     });
 
-    // Verificar si el avatar está disponible
     const avatarImage = document.querySelector('a.dropdown-trigger img');
-    const avatarSrc = avatarImage.src;
-    const avatarRequest = new XMLHttpRequest();
-    avatarRequest.open('GET', avatarSrc, true);
-    avatarRequest.onreadystatechange = function() {
-        if (avatarRequest.readyState === 4) {
-            if (avatarRequest.status !== 200) {
-                // Si el avatar no está disponible, usa el avatar por defecto
+    if (avatarImage) {
+        const req = new XMLHttpRequest();
+        req.open('GET', avatarImage.src, true);
+        req.onreadystatechange = function() {
+            if (req.readyState === 4 && req.status !== 200) {
                 avatarImage.src = '/images/avatar.webp';
             }
-        }
-    };
-    avatarRequest.send();
+        };
+        req.send();
+    }
 
-    // Solicitar unirse a una penca
     const joinBtn = document.getElementById('join-button');
     if (joinBtn) {
         joinBtn.addEventListener('click', async () => {
@@ -364,17 +250,16 @@ document.addEventListener('DOMContentLoaded', async function() {
         });
     }
 
-    // Cargar solicitudes y participantes para owners
     if (userRole === 'owner') {
         try {
             const resp = await fetch('/pencas/mine');
             const pencas = await resp.json();
             const container = document.getElementById('manage-content');
-            pencas.forEach(penca => {
+            pencas.forEach(p => {
                 const div = document.createElement('div');
-                div.innerHTML = `<h5>${penca.name}</h5>`;
+                div.innerHTML = `<h5>${p.name}</h5>`;
                 const pending = document.createElement('ul');
-                pending.innerHTML = penca.pendingRequests.map(u => `<li>${u.username || u}</li>`).join('');
+                pending.innerHTML = p.pendingRequests.map(u => `<li>${u.username || u}</li>`).join('');
                 div.appendChild(pending);
                 container.appendChild(div);
             });

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -33,51 +33,45 @@
     <main>
         <div class="container">
             <% if (pencas && pencas.length) { %>
-            <div class="row">
-                <div class="input-field col s12 m6">
-                    <select id="penca-select">
-                        <% pencas.forEach(function(p) { %>
-                            <option value="<%= p._id %>"><%= p.name %></option>
-                        <% }); %>
-                    </select>
-                    <label>Seleccionar Penca</label>
-                </div>
-            </div>
-            <% } %>
-            <ul class="tabs">
-                <li class="tab col s2"><a href="#fixture" class="<%= user.role === 'admin' ? 'active' : '' %>">Fixture</a></li>
-                <li class="tab col s2"><a href="#predictions" class="<%= user.role !== 'admin' ? 'active' : '' %>">Predicciones</a></li>
-                <li class="tab col s2"><a href="#ranking">Ranking</a></li>
-                <li class="tab col s2"><a href="#join">Unirse</a></li>
-                <% if (user.role === 'owner') { %>
-                    <li class="tab col s2"><a href="#manage">Mi Penca</a></li>
-                <% } %>
+            <ul id="pencas-collapsible" class="collapsible popout">
+                <% pencas.forEach(function(p) { %>
+                <li data-penca-id="<%= p._id %>">
+                    <div class="collapsible-header"><i class="material-icons">sports_soccer</i><%= p.name %></div>
+                    <div class="collapsible-body">
+                        <div class="row">
+                            <div class="col s12 m6">
+                                <h5>Fixture</h5>
+                                <div id="matches-list-<%= p._id %>" class="row"></div>
+                            </div>
+                            <div class="col s12 m6">
+                                <h5>Predicciones</h5>
+                                <div id="predictions-list-<%= p._id %>" class="row"></div>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col s12">
+                                <h5>Ranking</h5>
+                                <div id="ranking-list-<%= p._id %>" class="row"></div>
+                            </div>
+                        </div>
+                    </div>
+                </li>
+                <% }); %>
             </ul>
-            
-            <div id="fixture" class="col s12">
-                <div id="matches-list" class="row"></div>
-            </div>
-            <div id="predictions" class="col s12">
-                <div id="predictions-list" class="row"></div>
-            </div>
-            <div id="ranking" class="col s12">
-                <div id="ranking-list" class="row"></div>
-            </div>
-            <div id="join" class="col s12">
-                <div class="row">
-                    <div class="input-field col s12 m6">
-                        <input id="join-code" type="text">
-                        <label for="join-code">Código de Penca</label>
-                    </div>
-                    <div class="col s12 m6">
-                        <button id="join-button" class="btn waves-effect waves-light">Solicitar Unirse</button>
-                    </div>
-                    <div id="join-message" class="col s12"></div>
+            <% } %>
+            <div id="join" class="row">
+                <div class="input-field col s12 m6">
+                    <input id="join-code" type="text">
+                    <label for="join-code">Código de Penca</label>
                 </div>
+                <div class="col s12 m6">
+                    <button id="join-button" class="btn waves-effect waves-light">Solicitar Unirse</button>
+                </div>
+                <div id="join-message" class="col s12"></div>
             </div>
             <% if (user.role === 'owner') { %>
-            <div id="manage" class="col s12">
-                <div id="manage-content" class="row"></div>
+            <div id="manage" class="row">
+                <div id="manage-content" class="col s12"></div>
             </div>
             <% } %>
         </div>
@@ -116,6 +110,7 @@
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
     <script>window.DEBUG = <%= debug ? 'true' : 'false' %>;</script>
+    <script>window.PENCAS = <%- JSON.stringify(pencas) %>;</script>
     <script src="/js/dashboard.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- render each penca as a collapsible section in the dashboard
- expose `window.PENCAS` to the client
- restructure dashboard JS to populate collapsibles with fixture, predictions and ranking

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c6878959c8325b584c591717618e3