### PR TITLE
Update DB name

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install
 proyecto con la URL de tu base de datos MongoDB y las credenciales del administrador:
 
 ```bash
-MONGODB_URI=mongodb://<usuario>:<password>@<host>/<basedatos>
+MONGODB_URI=mongodb://<usuario>:<password>@<host>/pencas
 DEFAULT_ADMIN_USERNAME=<usuario_admin>
 DEFAULT_ADMIN_PASSWORD=<contraseña_admin>
 DEFAULT_COMPETITION=<nombre_competencia>

--- a/updateschema.js
+++ b/updateschema.js
@@ -22,7 +22,7 @@ const client = new MongoClient(uri, { useNewUrlParser: true, useUnifiedTopology:
 async function createSchema() {
     try {
         await client.connect();
-        const db = client.db('penca_copa_america');
+        const db = client.db('pencas');
         
         const usersCollection = db.collection('users');
         await usersCollection.createIndex({ username: 1 }, { unique: true });


### PR DESCRIPTION
## Summary
- set MongoDB database name to `pencas`
- use new database name in README examples

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c687981e88325a12348c33fb9bdd4