### PR TITLE
Fix join role check and owner participants

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -119,7 +119,7 @@ router.post('/pencas', isAuthenticated, isAdmin, jsonUpload.single('fixture'), a
             owner: ownerUser._id,
             participantLimit: participantLimit ? Number(participantLimit) : undefined,
             fixture: fixtureIds,
-            participants: [ownerUser._id]
+            participants: []
         });
 
         await penca.save();

--- a/routes/penca.js
+++ b/routes/penca.js
@@ -50,11 +50,11 @@ router.post('/', isAuthenticated, async (req, res) => {
       owner: ownerId,
       participantLimit,
       competition: competition || DEFAULT_COMPETITION,
-      participants: [ownerId]
+      participants: []
     });
     await penca.save();
     await User.updateOne({ _id: ownerId }, {
-      $addToSet: { ownedPencas: penca._id, pencas: penca._id },
+      $addToSet: { ownedPencas: penca._id },
       $set: { role: 'owner' }
     });
     res.status(201).json({ pencaId: penca._id, code: penca.code });
@@ -88,6 +88,9 @@ router.post('/join', isAuthenticated, async (req, res) => {
   const userId = req.session.user._id;
   const joined = req.session.user.pencas || [];
   try {
+    if (req.session.user.role !== 'user') {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
     if (joined.length >= 3) {
       return res.status(400).json({ error: 'You have reached the maximum number of pencas you can join' });
     }

--- a/tests/penca.test.js
+++ b/tests/penca.test.js
@@ -1,0 +1,62 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../models/Penca', () => {
+  return jest.fn(function (data) {
+    Object.assign(this, data);
+    this.save = jest.fn().mockResolvedValue(this);
+  });
+});
+
+jest.mock('../models/User', () => ({
+  updateOne: jest.fn()
+}));
+
+jest.mock('../middleware/auth', () => ({
+  isAuthenticated: jest.fn((req, res, next) => next())
+}));
+
+const Penca = require('../models/Penca');
+const User = require('../models/User');
+const pencaRouter = require('../routes/penca');
+
+describe('Penca Routes creation', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not add owner to participants when creating', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use((req, res, next) => { req.session = { user: { _id: 'u1' } }; next(); });
+    app.use('/pencas', pencaRouter);
+
+    const res = await request(app)
+      .post('/pencas')
+      .send({ name: 'Test', participantLimit: 10 });
+
+    expect(res.status).toBe(201);
+    expect(Penca.mock.calls[0][0].participants).toEqual([]);
+  });
+});
+
+describe('Penca join role check', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects join when user role is not "user"', async () => {
+    require('../models/Penca').findOne = jest.fn();
+    const app = express();
+    app.use(express.json());
+    app.use((req, res, next) => { req.session = { user: { _id: 'u1', role: 'owner', pencas: [] } }; next(); });
+    app.use('/pencas', pencaRouter);
+
+    const res = await request(app)
+      .post('/pencas/join')
+      .send({ code: 'ABC' });
+
+    expect(res.status).toBe(403);
+    expect(require('../models/Penca').findOne).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- restrict `/pencas/join` to normal users
- don't add owner to participants when creating a penca
- add regression tests for penca creation and join role

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c759fb0e083259a0395957a10283b