### PR TITLE
Conditional join form

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -261,7 +261,7 @@ document.addEventListener('DOMContentLoaded', async function() {
     }
 
     const joinBtn = document.getElementById('join-button');
-    if (joinBtn) {
+    if (userRole === 'user' && joinBtn) {
         joinBtn.addEventListener('click', async () => {
             const code = document.getElementById('join-code').value;
             try {

--- a/tests/dashboard.test.js
+++ b/tests/dashboard.test.js
@@ -1,0 +1,21 @@
+const path = require('path');
+const ejs = require('ejs');
+
+describe('Dashboard view', () => {
+  const tpl = path.join(__dirname, '..', 'views', 'dashboard.ejs');
+
+  it('does not render join form for admin role', async () => {
+    const html = await ejs.renderFile(tpl, { user: { role: 'admin', username: 'a' }, pencas: [], debug: false });
+    expect(html).not.toContain('id="join"');
+  });
+
+  it('does not render join form for owner role', async () => {
+    const html = await ejs.renderFile(tpl, { user: { role: 'owner', username: 'o' }, pencas: [], debug: false });
+    expect(html).not.toContain('id="join"');
+  });
+
+  it('renders join form for user role', async () => {
+    const html = await ejs.renderFile(tpl, { user: { role: 'user', username: 'u' }, pencas: [], debug: false });
+    expect(html).toContain('id="join"');
+  });
+});

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -61,6 +61,7 @@
             </ul>
             <% } %>
 
+            <% if (user.role === 'user') { %>
             <div id="join" class="row">
                 <div class="input-field col s12 m6">
                     <input id="join-code" type="text">
@@ -71,6 +72,7 @@
                 </div>
                 <div id="join-message" class="col s12"></div>
             </div>
+            <% } %>
 
             <% if (user.role === 'owner') { %>
             <div id="manage" class="row">


### PR DESCRIPTION
## Summary
- only render join form for users
- only attach join listener for users
- test join form visibility by role

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c75a869188325ae651ea1770836d4