### PR TITLE
Fix README conflict markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,8 @@ proyecto con la URL de tu base de datos MongoDB y las credenciales del administr
 La base de datos por defecto debe llamarse `pencas`:
 
 ```bash
-<<<<<<< codex/cambiar-nombre-de-base-de-datos-en-updateschema.js
-MONGODB_URI=mongodb://<usuario>:<password>@<host>/pencas
-=======
 # Ejemplo de conexión local
 MONGODB_URI=mongodb://localhost:27017/pencas
->>>>>>> main
 DEFAULT_ADMIN_USERNAME=<usuario_admin>
 DEFAULT_ADMIN_PASSWORD=<contraseña_admin>
 DEFAULT_COMPETITION=<nombre>


### PR DESCRIPTION
## Summary
- remove leftover merge conflict markers from README
- keep only a single example for `MONGODB_URI`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d6a87f98c8325bef1fca5fd6d9d3e