### PR TITLE
Remove reset matches feature

### DIFF
--- a/main.js
+++ b/main.js
@@ -281,23 +281,6 @@ app.post('/logout', (req, res) => {
     });
 });
 
-app.post('/reset-matches', isAdmin, async (req, res) => {
-    try {
-        const matches = require('./matches.json');
-        
-        await Match.deleteMany({});
-        await Prediction.deleteMany({});
-        await Score.updateMany({}, { $set: { score: 0 } });
-
-        await Match.insertMany(matches);
-
-        res.json({ success: true, message: 'Partidos y predicciones reseteados, y puntajes inicializados' });
-    } catch (err) {
-        console.error('Error al resetear partidos y predicciones', err);
-        res.status(500).json({ error: 'Error al resetear partidos y predicciones' });
-    }
-});
-
 app.use((req, res) => {
     res.status(404).send('404: Página no encontrada');
 });

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -18,9 +18,6 @@
                 <a href="#" data-target="info-modal" class="modal-trigger info-icon">
                     <img src="/images/info.png" alt="Info" class="circle responsive-img">
                 </a>
-                <% if (user.role === 'admin') { %>
-                    <a id="reset-matches-btn" class="btn red" style="margin-right: 10px;">Restablecer Partidos</a>
-                <% } %>
                 <a class="dropdown-trigger" href="#!" data-target="user-dropdown">
                     <img src="<%= user.avatar ? '/avatar/' + user.username : '/images/avatar.webp' %>" alt="Avatar" class="circle responsive-img">
                 </a>


### PR DESCRIPTION
## Summary
- remove `/reset-matches` route from **main.js**
- drop "Restablecer Partidos" button from **dashboard.ejs**

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d70602e8c8325baa4e680d164743a