### PR TITLE
Fix ObjectId comparison in penca and predictions routes

### DIFF
--- a/routes/penca.js
+++ b/routes/penca.js
@@ -102,7 +102,10 @@ router.post('/join', isAuthenticated, async (req, res) => {
 
     if (!penca) return res.status(404).json({ error: 'Penca not found' });
 
-    if (penca.participants.includes(userId) || penca.pendingRequests.includes(userId)) {
+    if (
+      penca.participants.some(id => id.equals(userId)) ||
+      penca.pendingRequests.some(id => id.equals(userId))
+    ) {
       return res.status(400).json({ error: 'Already requested or member' });
     }
     if (penca.participantLimit && penca.participants.length >= penca.participantLimit) {
@@ -128,7 +131,7 @@ router.post('/approve/:pencaId/:userId', isAuthenticated, async (req, res) => {
       return res.status(403).json({ error: 'Forbidden' });
     }
     penca.pendingRequests = penca.pendingRequests.filter(id => id.toString() !== userId);
-    if (!penca.participants.includes(userId)) {
+    if (!penca.participants.some(id => id.equals(userId))) {
       penca.participants.push(userId);
       await User.updateOne({ _id: userId }, { $addToSet: { pencas: penca._id } });
     }

--- a/routes/predictions.js
+++ b/routes/predictions.js
@@ -33,7 +33,7 @@ router.post('/', async (req, res) => {
         }
 
         const penca = await Penca.findById(pencaId);
-        if (!penca || !penca.participants.includes(user._id)) {
+        if (!penca || !penca.participants.some(id => id.equals(user._id))) {
             return res.status(403).json({ error: 'No pertenece a la penca' });
         }
 


### PR DESCRIPTION
## Summary
- use `some(id => id.equals(userId))` when checking for user membership in arrays

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d7060630c8325b4f6247f138cc4a3