### PR TITLE
Filter matches by competition

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -58,13 +58,23 @@ document.addEventListener('DOMContentLoaded', async function() {
         const allPreds = await fetch('/predictions').then(r => r.json());
 
         for (const penca of pencas) {
-            const userPreds = allPreds.filter(p => p.username === username && p.pencaId === penca._id);
+            const pencaMatches = matches.filter(m => {
+                if (Array.isArray(penca.fixture) && penca.fixture.length) {
+                    return penca.fixture.some(id => id.toString() === m._id.toString());
+                }
+                if (penca.competition) {
+                    return m.competition === penca.competition;
+                }
+                return true;
+            });
+            const matchIds = pencaMatches.map(m => m._id.toString());
+            const userPreds = allPreds.filter(p => p.username === username && p.pencaId === penca._id && matchIds.includes(p.matchId.toString()));
             const matchesList = document.getElementById(`matches-list-${penca._id}`);
             const predsList = document.getElementById(`predictions-list-${penca._id}`);
             matchesList.innerHTML = '';
             predsList.innerHTML = '';
 
-            matches.forEach(match => {
+            pencaMatches.forEach(match => {
                 const team1Flag = normalizeName(match.team1);
                 const team2Flag = normalizeName(match.team2);
                 const userPrediction = userPreds.find(pr => pr.matchId.toString() === match._id.toString());

--- a/tests/ranking.test.js
+++ b/tests/ranking.test.js
@@ -49,4 +49,17 @@ describe('GET /ranking', () => {
     expect(res.body.length).toBe(1);
     expect(res.body[0].userId).toBe('u1');
   });
+
+  it('returns scores for a competition', async () => {
+    User.find.mockResolvedValue([{ _id: 'u1', username: 'compu' }]);
+    Match.find.mockResolvedValue([{ _id: 'm1', competition: 'c1', result1: 2, result2: 1 }]);
+    Prediction.find.mockResolvedValue([{ userId: 'u1', matchId: 'm1', result1: 2, result2: 1 }]);
+
+    const app = express();
+    app.use('/ranking', rankingRouter);
+
+    const res = await request(app).get('/ranking/competition/c1');
+    expect(res.status).toBe(200);
+    expect(res.body[0].userId).toBe('u1');
+  });
 });


### PR DESCRIPTION
## Summary
- filter matches and predictions by each penca fixture or competition in dashboard
- enhance ranking calculation with fixture/competition filtering
- add endpoint `/ranking/competition/:competition` for competition-only rankings
- update unit tests

## Testing
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685d706117e08325b37b103ad00b80e9