### PR TITLE
Document and configure user penca limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,12 @@ DEFAULT_COMPETITION=<nombre>
 SESSION_SECRET=<tu_clave>
 # Opcionalmente puedes definir el puerto de la app
 PORT=3000
+# Límite de pencas que un usuario puede unir (3 por defecto)
+MAX_PENCAS_PER_USER=3
 ```
 Si no defines `SESSION_SECRET`, el servidor se cerrará al iniciarse.
+El valor `MAX_PENCAS_PER_USER` controla cuántas pencas puede integrar cada usuario,
+útil si planeas varias competiciones en paralelo.
 
 3. Inicia el servidor en modo desarrollo con **nodemon**:
 

--- a/config.js
+++ b/config.js
@@ -1,3 +1,4 @@
 module.exports = {
-    DEFAULT_COMPETITION: process.env.DEFAULT_COMPETITION || 'Copa America 2024'
+    DEFAULT_COMPETITION: process.env.DEFAULT_COMPETITION || 'Copa America 2024',
+    MAX_PENCAS_PER_USER: parseInt(process.env.MAX_PENCAS_PER_USER || '3', 10)
 };

--- a/routes/penca.js
+++ b/routes/penca.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const Penca = require('../models/Penca');
 const User = require('../models/User');
 const { isAuthenticated } = require('../middleware/auth');
-const { DEFAULT_COMPETITION } = require('../config');
+const { DEFAULT_COMPETITION, MAX_PENCAS_PER_USER } = require('../config');
 
 // Listar todas las pencas (nombre y código)
 router.get('/', isAuthenticated, async (req, res) => {
@@ -91,8 +91,8 @@ router.post('/join', isAuthenticated, async (req, res) => {
     if (req.session.user.role !== 'user') {
       return res.status(403).json({ error: 'Forbidden' });
     }
-    if (joined.length >= 3) {
-      return res.status(400).json({ error: 'You have reached the maximum number of pencas you can join' });
+    if (joined.length >= MAX_PENCAS_PER_USER) {
+      return res.status(400).json({ error: `You have reached the maximum number of pencas you can join (${MAX_PENCAS_PER_USER})` });
     }
 
     const query = { code };


### PR DESCRIPTION
## Summary
- make the maximum number of pencas per user configurable
- describe the `MAX_PENCAS_PER_USER` environment variable in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d70625c008325b051b8c5bf9297dc