### PR TITLE
Add fallback when pencas list empty

### DIFF
--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -56,6 +56,8 @@
                 </li>
                 <% }); %>
             </ul>
+            <% } else { %>
+            <p>Aún no formas parte de ninguna penca</p>
             <% } %>
 
             <% if (user.role === 'user') { %>


### PR DESCRIPTION
## Summary
- adjust dashboard to show a friendly message when no pencas are available

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863dca6814c8325835d20ce050a959d