### PR TITLE
Improve admin edit error logging

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -38,7 +38,7 @@ router.get('/edit', isAuthenticated, isAdmin, async (req, res) => {
         const users = await User.find().select('username');
         res.render('admin', { user: req.session.user, users });
     } catch (error) {
-        console.error('Error al cargar la página de administración:', error);
+        console.error('Admin edit load error:', error.message, error.stack);
         res.status(500).send('Error al cargar la página de administración');
     }
 });


### PR DESCRIPTION
## Summary
- log error stack in `/admin/edit` route for better traceability

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68640e976de8832582744b19644031fb