### PR TITLE
Implement admin user pagination

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -35,7 +35,18 @@ const jsonUpload = multer({
 // Página de administración
 router.get('/edit', isAuthenticated, isAdmin, async (req, res) => {
     try {
-        const users = await User.find().select('username');
+        const page = parseInt(req.query.page) || 0;
+        const limit = parseInt(req.query.limit) || 10;
+
+        const users = await User.find()
+            .select('username')
+            .skip(page * limit)
+            .limit(limit);
+
+        if (req.headers.accept && req.headers.accept.includes('application/json')) {
+            return res.json(users);
+        }
+
         res.render('admin', { user: req.session.user, users });
     } catch (error) {
         console.error('Admin edit load error:', error.message, error.stack);

--- a/tests/admin.test.js
+++ b/tests/admin.test.js
@@ -35,6 +35,7 @@ jest.mock('../models/User', () => {
   UserMock.findOne = jest.fn();
   UserMock.deleteOne = jest.fn();
   UserMock.updateOne = jest.fn();
+  UserMock.find = jest.fn();
   return UserMock;
 });
 
@@ -251,5 +252,30 @@ describe('Admin penca modification', () => {
 
     expect(res.status).toBe(200);
     expect(User.updateOne).toHaveBeenCalled();
+  });
+});
+
+describe('Admin edit pagination', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('paginates users based on query', async () => {
+    const query = {
+      select: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockResolvedValue([{ username: 'u1' }])
+    };
+    User.find.mockReturnValue(query);
+
+    const app = express();
+    app.use('/admin', adminRouter);
+
+    const res = await request(app)
+      .get('/admin/edit')
+      .query({ page: '2', limit: '5' })
+      .set('Accept', 'application/json');
+
+    expect(res.status).toBe(200);
+    expect(query.skip).toHaveBeenCalledWith(10);
+    expect(query.limit).toHaveBeenCalledWith(5);
   });
 });

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -36,6 +36,12 @@
             </select>
             <label>Seleccionar Usuario</label>
           </div>
+          <div class="col s6 m3">
+            <button id="prev-users" class="btn waves-effect waves-light" type="button">Anterior</button>
+          </div>
+          <div class="col s6 m3">
+            <button id="next-users" class="btn waves-effect waves-light" type="button">Siguiente</button>
+          </div>
         </div>
         <form id="editUserForm" class="row" method="POST" action="/admin/update" enctype="multipart/form-data">
           <!-- Aquí van los campos del usuario que se van a editar -->
@@ -178,6 +184,27 @@
       M.Tabs.init(document.querySelectorAll('.tabs'));
       M.FormSelect.init(document.querySelectorAll('select'));
 
+      let userPage = 0;
+      const userLimit = 10;
+
+      function loadUsers() {
+        const select = document.getElementById('user-select');
+        if (!select) return;
+
+        fetch(`/admin/edit?page=${userPage}&limit=${userLimit}`, { headers: { Accept: 'application/json' } })
+          .then(r => r.json())
+          .then(data => {
+            select.innerHTML = '<option value="" disabled selected>Elige un usuario</option>';
+            data.forEach(u => {
+              const opt = document.createElement('option');
+              opt.value = u.username;
+              opt.textContent = u.username;
+              select.appendChild(opt);
+            });
+            M.FormSelect.init(select);
+          });
+      }
+
       function loadOwners() {
         const select1 = document.getElementById('pencaOwner');
         const select2 = document.getElementById('editPencaOwner');
@@ -250,9 +277,32 @@
         }
       }
 
+      function setupUserPagination() {
+        const nextBtn = document.getElementById('next-users');
+        const prevBtn = document.getElementById('prev-users');
+        if (nextBtn) {
+          nextBtn.addEventListener('click', e => {
+            e.preventDefault();
+            userPage++;
+            loadUsers();
+          });
+        }
+        if (prevBtn) {
+          prevBtn.addEventListener('click', e => {
+            e.preventDefault();
+            if (userPage > 0) {
+              userPage--;
+              loadUsers();
+            }
+          });
+        }
+      }
+
+      loadUsers();
       loadOwners();
       loadCompetitions();
       loadPencas();
+      setupUserPagination();
       setupRecalculateButton();
     });
   </script>


### PR DESCRIPTION
## Summary
- enable pagination in admin edit route using `page` and `limit` query params
- add AJAX pagination controls in `admin.ejs`
- cover pagination logic with new unit test

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68641d1d1d008325b119dd435a9853d3