### PR TITLE
Add API-Football fixture support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ SESSION_SECRET=<tu_clave>
 PORT=3000
 # Límite de pencas que un usuario puede unir (3 por defecto)
 MAX_PENCAS_PER_USER=3
+# Credenciales para obtener fixtures desde API-Football
+FOOTBALL_API_KEY=<tu_api_key>
+# Identificador de liga y temporada
+FOOTBALL_LEAGUE_ID=<id_liga>
+FOOTBALL_SEASON=<temporada>
+# URL base opcional de la API
+FOOTBALL_API_URL=https://v3.football.api-sports.io
 ```
 Si no defines `SESSION_SECRET`, el servidor se cerrará al iniciarse.
 El valor `MAX_PENCAS_PER_USER` controla cuántas pencas puede integrar cada usuario,

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -267,7 +267,44 @@ router.post('/competitions', isAuthenticated, isAdmin, jsonUpload.single('fixtur
             matchesData.forEach(m => { if (!m.competition) m.competition = name; });
             await Match.insertMany(matchesData);
         } else if (String(useApi) === 'true') {
-            // TODO: Integrar API-Football
+            const {
+                FOOTBALL_API_KEY,
+                FOOTBALL_LEAGUE_ID,
+                FOOTBALL_SEASON,
+                FOOTBALL_API_URL
+            } = process.env;
+
+            if (!FOOTBALL_API_KEY || !FOOTBALL_LEAGUE_ID || !FOOTBALL_SEASON) {
+                throw new Error('Football API env vars missing');
+            }
+
+            const base = FOOTBALL_API_URL || 'https://v3.football.api-sports.io';
+            const response = await fetch(
+                `${base}/fixtures?league=${FOOTBALL_LEAGUE_ID}&season=${FOOTBALL_SEASON}`,
+                { headers: { 'x-apisports-key': FOOTBALL_API_KEY } }
+            );
+
+            if (!response.ok) {
+                throw new Error('Failed to fetch fixtures');
+            }
+
+            const apiData = await response.json();
+            const matchesData = (apiData.response || []).map(f => ({
+                date: f.fixture?.date?.slice(0, 10) || '',
+                time: f.fixture?.date?.slice(11, 16) || '',
+                team1: f.teams?.home?.name || '',
+                team2: f.teams?.away?.name || '',
+                competition: name,
+                group_name: f.league?.round || '',
+                series: String(f.fixture?.id || ''),
+                tournament: f.league?.name || '',
+                result1: f.goals?.home ?? null,
+                result2: f.goals?.away ?? null
+            }));
+
+            if (matchesData.length) {
+                await Match.insertMany(matchesData);
+            }
         }
 
         res.status(201).json({ competitionId: competition._id });


### PR DESCRIPTION
## Summary
- fetch fixtures from API-Football when creating a competition with `useApi=true`
- save matches retrieved from the API
- document environment variables for the API

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68641d1de3a483259de08f430ee66fe1