### PR TITLE
Add competition selection for pencas

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -7,6 +7,7 @@ const Match = require('../models/Match');
 const Penca = require('../models/Penca');
 const Competition = require('../models/Competition');
 const { isAuthenticated, isAdmin } = require('../middleware/auth');
+const { DEFAULT_COMPETITION } = require('../config');
 
 const storage = multer.memoryStorage();
 const upload = multer({ 
@@ -177,7 +178,7 @@ router.delete('/owners/:id', isAuthenticated, isAdmin, async (req, res) => {
 // Crear penca
 router.post('/pencas', isAuthenticated, isAdmin, jsonUpload.single('fixture'), async (req, res) => {
     try {
-        const { name, owner, participantLimit } = req.body;
+        const { name, owner, participantLimit, competition } = req.body;
         if (!name) return res.status(400).json({ error: 'Name required' });
 
         const ownerUser = owner ? await User.findById(owner) : req.session.user;
@@ -194,6 +195,7 @@ router.post('/pencas', isAuthenticated, isAdmin, jsonUpload.single('fixture'), a
             name,
             code: Math.random().toString(36).substring(2, 8).toUpperCase(),
             owner: ownerUser._id,
+            competition: competition || DEFAULT_COMPETITION,
             participantLimit: participantLimit ? Number(participantLimit) : undefined,
             fixture: fixtureIds,
             participants: []
@@ -226,7 +228,7 @@ router.get('/pencas', isAuthenticated, isAdmin, async (req, res) => {
 // Actualizar penca
 router.put('/pencas/:id', isAuthenticated, isAdmin, async (req, res) => {
     try {
-        const { name, participantLimit, owner } = req.body;
+        const { name, participantLimit, owner, competition } = req.body;
         const penca = await Penca.findById(req.params.id);
         if (!penca) return res.status(404).json({ error: 'Penca not found' });
 
@@ -241,6 +243,7 @@ router.put('/pencas/:id', isAuthenticated, isAdmin, async (req, res) => {
 
         if (name) penca.name = name;
         if (participantLimit !== undefined) penca.participantLimit = Number(participantLimit);
+        if (competition) penca.competition = competition;
 
         await penca.save();
         res.json({ message: 'Penca updated' });

--- a/tests/admin.test.js
+++ b/tests/admin.test.js
@@ -71,13 +71,15 @@ describe('Admin penca creation', () => {
       .field('name', 'Test')
       .field('owner', 'u1')
       .field('participantLimit', '10')
+      .field('competition', 'Comp1')
       .attach('fixture', Buffer.from(JSON.stringify(fixture)), 'fixture.json');
 
     expect(res.status).toBe(201);
     expect(Penca).toHaveBeenCalledWith(expect.objectContaining({
       name: 'Test',
       owner: 'u1',
-      participantLimit: 10
+      participantLimit: 10,
+      competition: 'Comp1'
     }));
     expect(Match.insertMany).toHaveBeenCalled();
   });
@@ -240,6 +242,22 @@ describe('Admin penca modification', () => {
     expect(res.status).toBe(200);
     expect(penca.owner).toBe('u2');
     expect(User.updateOne).toHaveBeenCalled();
+  });
+
+  it('updates a penca competition', async () => {
+    const penca = { _id: 'p1', save: jest.fn().mockResolvedValue(true) };
+    Penca.findById.mockResolvedValue(penca);
+
+    const app = express();
+    app.use(express.json());
+    app.use('/admin', adminRouter);
+
+    const res = await request(app)
+      .put('/admin/pencas/p1')
+      .send({ competition: 'NewComp' });
+
+    expect(res.status).toBe(200);
+    expect(penca.competition).toBe('NewComp');
   });
 
   it('deletes a penca', async () => {

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -117,6 +117,10 @@
             <select id="pencaOwner"></select>
             <label>Owner</label>
           </div>
+          <div class="input-field col s12">
+            <select id="pencaCompetition"></select>
+            <label>Competencia</label>
+          </div>
           <div class="file-field input-field col s12">
             <div class="btn">
               <span>Fixture JSON</span>
@@ -148,6 +152,10 @@
           <div class="input-field col s12">
             <select id="editPencaOwner"></select>
             <label>Owner</label>
+          </div>
+          <div class="input-field col s12">
+            <select id="editPencaCompetition"></select>
+            <label>Competencia</label>
           </div>
           <div class="col s12">
             <button class="btn waves-effect waves-light" type="submit">Guardar</button>
@@ -226,19 +234,23 @@
 
       function loadCompetitions() {
         const list = document.getElementById('competitionList');
-        const select = document.getElementById('competitionSelectEdit');
+        const selectComp = document.getElementById('competitionSelectEdit');
+        const selectPencaCreate = document.getElementById('pencaCompetition');
+        const selectPencaEdit = document.getElementById('editPencaCompetition');
         fetch('/admin/competitions').then(r => r.json()).then(data => {
           if (list) list.innerHTML = data.map(c => `<li class="collection-item">${c.name}</li>`).join('');
-          if (select) {
-            select.innerHTML = '<option value=\"\" disabled selected>Seleccione competencia</option>';
-            data.forEach(c => {
-              const opt = document.createElement('option');
-              opt.value = c._id;
-              opt.textContent = c.name;
-              select.appendChild(opt);
-            });
-            M.FormSelect.init(select);
-          }
+          [selectComp, selectPencaCreate, selectPencaEdit].forEach(select => {
+            if (select) {
+              select.innerHTML = '<option value=\"\" disabled selected>Seleccione competencia</option>';
+              data.forEach(c => {
+                const opt = document.createElement('option');
+                opt.value = select === selectComp ? c._id : c.name;
+                opt.textContent = c.name;
+                select.appendChild(opt);
+              });
+              M.FormSelect.init(select);
+            }
+          });
         });
       }
 


### PR DESCRIPTION
## Summary
- allow creating and editing pencas with a selected competition
- show competition select boxes in admin forms
- load competitions for these new dropdowns
- test updating penca competitions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68643f2d22548325be6f62b28923aa46