### PR TITLE
Fix admin navigation and unify links

### DIFF
--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -15,14 +15,6 @@
     <h4 class="center-align">Panel de Administración</h4>
 
     <div class="row">
-      <div class="col s12">
-        <ul class="tabs tabs-fixed-width">
-          <li class="tab col s3"><a class="active" href="#users">Usuarios</a></li>
-          <li class="tab col s3"><a href="#competitions">Competiciones</a></li>
-          <li class="tab col s3"><a href="#pencas">Pencas</a></li>
-          <li class="tab col s3"><a href="#config">Configuración</a></li>
-        </ul>
-      </div>
 
       <div id="users" class="col s12">
         <%- include('admin/partials/users') %>
@@ -33,7 +25,10 @@
       <div id="pencas" class="col s12">
         <%- include('admin/partials/pencas') %>
       </div>
-      <div id="config" class="col s12">
+      <div id="owners" class="col s12">
+        <%- include('admin/partials/owners') %>
+      </div>
+      <div id="settings" class="col s12">
         <%- include('admin/partials/settings') %>
       </div>
     </div>

--- a/views/admin/partials/owners.ejs
+++ b/views/admin/partials/owners.ejs
@@ -1,0 +1,6 @@
+<div class="row">
+  <div class="col s12">
+    <h5>Owners Management</h5>
+    <p>Aún no se ha implementado la interfaz de administración de owners.</p>
+  </div>
+</div>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -37,27 +37,25 @@
       </ul>
   
       <ul class="sidenav" id="mobile-nav">
-        <% if (user.role === 'admin') { %><li><a href="/dashboard">Dashboard</a></li><% } %>
+        <% if (user.role === 'admin') { %>
+          <li><a href="#users">Users</a></li>
+          <li><a href="#competitions">Competitions</a></li>
+          <li><a href="#pencas">Pencas</a></li>
+          <li><a href="#owners">Owners</a></li>
+          <li><a href="#settings">Settings</a></li>
+        <% } %>
         <li><form action="/logout" method="POST"><button type="submit" class="btn blue darken-2 white-text" style="width:100%;">Cerrar sesión</button></form></li>
       </ul>
     <% } %>
-<<<<<<< Updated upstream
     <% if (user && user.role === 'admin') { %>
-        <ul class="sidenav" id="mobile-demo">
-            <li><a href="/dashboard">Dashboard</a></li>
-            <li><a href="#" id="logout-button-mobile">Cerrar sesión</a></li>
+      <div class="nav-content">
+        <ul class="tabs tabs-transparent blue darken-3">
+          <li class="tab"><a class="active" href="#users">Users</a></li>
+          <li class="tab"><a href="#competitions">Competitions</a></li>
+          <li class="tab"><a href="#pencas">Pencas</a></li>
+          <li class="tab"><a href="#owners">Owners</a></li>
+          <li class="tab"><a href="#settings">Settings</a></li>
         </ul>
-        <div class="nav-content">
-            <ul class="tabs tabs-transparent blue darken-3">
-                <li class="tab"><a class="active" href="#users">Users</a></li>
-                <li class="tab"><a href="#competitions">Competitions</a></li>
-                <li class="tab"><a href="#pencas">Pencas</a></li>
-                <li class="tab"><a href="#owners">Owners</a></li>
-                <li class="tab"><a href="#settings">Settings</a></li>
-            </ul>
-        </div>
+      </div>
     <% } %>
 </header>
-=======
-  </header>
->>>>>>> Stashed changes


### PR DESCRIPTION
## Summary
- resolve merge conflict in admin header
- add Owners tab placeholder
- sync desktop tabs and mobile navigation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864510c879c83258fbc38b73c9e5ab9