### PR TITLE
Add participant tests and document Node 18+

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Aplicación web desarrollada en **Node.js** y **Express** para administrar una
 penca de la Copa América 2024. Los usuarios pueden registrarse, realizar 
 predicciones de los partidos y consultar el ranking general.
 
+Esta aplicación requiere Node.js 18 o superior para utilizar la función `fetch` en el backend.
+
 ## Instalación
 
 1. Instala las dependencias del proyecto:

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
     "supertest": "^6.3.3"
   },
   "author": "Ren",
-  "license": "ISC"
+  "license": "ISC",
+  "engines": {
+    "node": ">=18"
+  }
 }

--- a/tests/penca.test.js
+++ b/tests/penca.test.js
@@ -60,3 +60,54 @@ describe('Penca join role check', () => {
     expect(require('../models/Penca').findOne).not.toHaveBeenCalled();
   });
 });
+
+describe('Penca participant approval and removal', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('approves a pending participant', async () => {
+    const penca = {
+      _id: 'p1',
+      owner: 'o1',
+      participants: [],
+      pendingRequests: ['u2'],
+      save: jest.fn().mockResolvedValue(true)
+    };
+    Penca.findById = jest.fn().mockResolvedValue(penca);
+
+    const app = express();
+    app.use(express.json());
+    app.use((req, res, next) => { req.session = { user: { _id: 'o1' } }; next(); });
+    app.use('/pencas', pencaRouter);
+
+    const res = await request(app).post('/pencas/approve/p1/u2');
+
+    expect(res.status).toBe(200);
+    expect(penca.pendingRequests).toEqual([]);
+    expect(penca.participants).toContain('u2');
+    expect(User.updateOne).toHaveBeenCalledWith({ _id: 'u2' }, { $addToSet: { pencas: penca._id } });
+  });
+
+  it('removes a participant', async () => {
+    const penca = {
+      _id: 'p1',
+      owner: 'o1',
+      participants: ['u2'],
+      pendingRequests: [],
+      save: jest.fn().mockResolvedValue(true)
+    };
+    Penca.findById = jest.fn().mockResolvedValue(penca);
+
+    const app = express();
+    app.use(express.json());
+    app.use((req, res, next) => { req.session = { user: { _id: 'o1' } }; next(); });
+    app.use('/pencas', pencaRouter);
+
+    const res = await request(app).delete('/pencas/participant/p1/u2');
+
+    expect(res.status).toBe(200);
+    expect(penca.participants).not.toContain('u2');
+    expect(User.updateOne).toHaveBeenCalledWith({ _id: 'u2' }, { $pull: { pencas: penca._id } });
+  });
+});


### PR DESCRIPTION
## Summary
- note Node.js 18+ requirement for backend fetch
- specify engines in package.json
- add tests for approving and removing participants

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686458aeffd08325a11ea26cf1737681