### PR TITLE
Add admin panel edit forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Aplicación web desarrollada en **Node.js** y **Express** para administrar una
 penca de la Copa América 2024. Los usuarios pueden registrarse, realizar 
 predicciones de los partidos y consultar el ranking general.
 
+Esta aplicación requiere Node.js 18 o superior para utilizar la función `fetch` en el backend.
+
 ## Instalación
 
 1. Instala las dependencias del proyecto:

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
     "supertest": "^6.3.3"
   },
   "author": "Ren",
-  "license": "ISC"
+  "license": "ISC",
+  "engines": {
+    "node": ">=18"
+  }
 }

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -55,8 +55,10 @@ function initTabs() {
   function loadOwners() {
     const select1 = document.getElementById('pencaOwner');
     const select2 = document.getElementById('editPencaOwner');
+    const editSelect = document.getElementById('ownerSelectEdit');
+    const list = document.getElementById('ownerList');
     fetch('/admin/owners').then(r => r.json()).then(data => {
-      [select1, select2].forEach(select => {
+      [select1, select2, editSelect].forEach(select => {
         if (select) {
           select.innerHTML = '<option value="" disabled selected>Seleccione Owner</option>';
           data.forEach(o => {
@@ -68,6 +70,13 @@ function initTabs() {
           initSelects();
         }
       });
+      if (list) {
+        list.innerHTML = data.map(o => `
+          <li class="collection-item">
+            ${o.username}
+            <a href="#" class="secondary-content red-text delete-owner" data-id="${o._id}"><i class="material-icons">delete</i></a>
+          </li>`).join('');
+      }
     });
   }
   
@@ -89,6 +98,17 @@ function initTabs() {
           opt.value = c._id;
           opt.textContent = c.name;
           select.appendChild(opt);
+        });
+        initSelects();
+      }
+      const compSelectEdit = document.getElementById('editPencaCompetition');
+      if (compSelectEdit) {
+        compSelectEdit.innerHTML = '<option value="" disabled selected>Seleccione competencia</option>';
+        data.forEach(c => {
+          const opt = document.createElement('option');
+          opt.value = c._id;
+          opt.textContent = c.name;
+          compSelectEdit.appendChild(opt);
         });
         initSelects();
       }
@@ -115,6 +135,119 @@ function initTabs() {
           select.appendChild(opt);
         });
         initSelects();
+      }
+    });
+  }
+
+  function setupOwnerForms() {
+    const form = document.getElementById('owner-form');
+    form?.addEventListener('submit', async e => {
+      e.preventDefault();
+      const data = {
+        username: document.getElementById('ownerUser').value,
+        email: document.getElementById('ownerEmail').value,
+        password: document.getElementById('ownerPassword').value
+      };
+      try {
+        const resp = await fetch('/admin/owners', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(data)
+        });
+        if (resp.ok) {
+          form.reset();
+          loadOwners();
+          M.toast({ html: 'Owner creado', classes: 'green' });
+        } else {
+          M.toast({ html: 'Error al crear owner', classes: 'red' });
+        }
+      } catch (err) {
+        console.error(err);
+        M.toast({ html: 'Error al crear owner', classes: 'red' });
+      }
+    });
+
+    const edit = document.getElementById('owner-edit-form');
+    edit?.addEventListener('submit', async e => {
+      e.preventDefault();
+      const id = document.getElementById('ownerSelectEdit').value;
+      const data = {
+        username: document.getElementById('ownerEditUsername').value || undefined,
+        email: document.getElementById('ownerEditEmail').value || undefined
+      };
+      try {
+        const resp = await fetch(`/admin/owners/${id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(data)
+        });
+        if (resp.ok) {
+          edit.reset();
+          loadOwners();
+          M.toast({ html: 'Owner actualizado', classes: 'green' });
+        } else {
+          M.toast({ html: 'Error al actualizar', classes: 'red' });
+        }
+      } catch (err) {
+        console.error(err);
+        M.toast({ html: 'Error al actualizar', classes: 'red' });
+      }
+    });
+  }
+
+  function setupCompetitionEditForm() {
+    const form = document.getElementById('competition-edit-form');
+    form?.addEventListener('submit', async e => {
+      e.preventDefault();
+      const id = document.getElementById('competitionSelectEdit').value;
+      const name = document.getElementById('competitionNewName').value;
+      try {
+        const resp = await fetch(`/admin/competitions/${id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name })
+        });
+        if (resp.ok) {
+          form.reset();
+          loadCompetitions();
+          M.toast({ html: 'Competencia actualizada', classes: 'green' });
+        } else {
+          M.toast({ html: 'Error al actualizar competencia', classes: 'red' });
+        }
+      } catch (err) {
+        console.error(err);
+        M.toast({ html: 'Error al actualizar competencia', classes: 'red' });
+      }
+    });
+  }
+
+  function setupPencaEditForm() {
+    const form = document.getElementById('penca-edit-form');
+    form?.addEventListener('submit', async e => {
+      e.preventDefault();
+      const id = document.getElementById('editPencaSelect').value;
+      const data = {
+        name: document.getElementById('editPencaName').value || undefined,
+        participantLimit: document.getElementById('editPencaLimit').value || undefined,
+        owner: document.getElementById('editPencaOwner').value || undefined,
+        competition: document.getElementById('editPencaCompetition').value || undefined
+      };
+      try {
+        const resp = await fetch(`/admin/pencas/${id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(data)
+        });
+        if (resp.ok) {
+          form.reset();
+          loadPencas();
+          M.toast({ html: 'Penca actualizada', classes: 'green' });
+        } else {
+          M.toast({ html: 'Error al actualizar penca', classes: 'red' });
+        }
+      } catch (err) {
+        console.error(err);
+        M.toast({ html: 'Error al actualizar penca', classes: 'red' });
       }
     });
   }
@@ -157,6 +290,16 @@ function initTabs() {
             .catch(err => console.error(err));
         }
       }
+
+      if (e.target.closest('.delete-owner')) {
+        e.preventDefault();
+        const id = e.target.closest('.delete-owner').dataset.id;
+        if (confirm('¿Eliminar owner?')) {
+          fetch(`/admin/owners/${id}`, { method: 'DELETE' })
+            .then(() => loadOwners())
+            .catch(err => console.error(err));
+        }
+      }
     });
   }
   
@@ -169,6 +312,9 @@ function initTabs() {
     loadOwners();
     loadCompetitions();
     loadPencas();
+    setupOwnerForms();
+    setupCompetitionEditForm();
+    setupPencaEditForm();
     setupRecalculateButton();
     setupDeleteHandlers();
   });

--- a/routes/penca.js
+++ b/routes/penca.js
@@ -28,7 +28,8 @@ router.get('/mine', isAuthenticated, async (req, res) => {
 
     const pencas = await Penca.find(filter)
       .select('name code competition participants pendingRequests')
-      .populate('pendingRequests', 'username');
+      .populate('pendingRequests', 'username')
+      .populate('participants', 'username');
 
     res.json(pencas);
   } catch (err) {

--- a/tests/penca.test.js
+++ b/tests/penca.test.js
@@ -60,3 +60,54 @@ describe('Penca join role check', () => {
     expect(require('../models/Penca').findOne).not.toHaveBeenCalled();
   });
 });
+
+describe('Penca participant approval and removal', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('approves a pending participant', async () => {
+    const penca = {
+      _id: 'p1',
+      owner: 'o1',
+      participants: [],
+      pendingRequests: ['u2'],
+      save: jest.fn().mockResolvedValue(true)
+    };
+    Penca.findById = jest.fn().mockResolvedValue(penca);
+
+    const app = express();
+    app.use(express.json());
+    app.use((req, res, next) => { req.session = { user: { _id: 'o1' } }; next(); });
+    app.use('/pencas', pencaRouter);
+
+    const res = await request(app).post('/pencas/approve/p1/u2');
+
+    expect(res.status).toBe(200);
+    expect(penca.pendingRequests).toEqual([]);
+    expect(penca.participants).toContain('u2');
+    expect(User.updateOne).toHaveBeenCalledWith({ _id: 'u2' }, { $addToSet: { pencas: penca._id } });
+  });
+
+  it('removes a participant', async () => {
+    const penca = {
+      _id: 'p1',
+      owner: 'o1',
+      participants: ['u2'],
+      pendingRequests: [],
+      save: jest.fn().mockResolvedValue(true)
+    };
+    Penca.findById = jest.fn().mockResolvedValue(penca);
+
+    const app = express();
+    app.use(express.json());
+    app.use((req, res, next) => { req.session = { user: { _id: 'o1' } }; next(); });
+    app.use('/pencas', pencaRouter);
+
+    const res = await request(app).delete('/pencas/participant/p1/u2');
+
+    expect(res.status).toBe(200);
+    expect(penca.participants).not.toContain('u2');
+    expect(User.updateOne).toHaveBeenCalledWith({ _id: 'u2' }, { $pull: { pencas: penca._id } });
+  });
+});

--- a/views/admin/partials/competitions.ejs
+++ b/views/admin/partials/competitions.ejs
@@ -26,8 +26,25 @@
     </div>
   </form>
 </div>
-  
-  <ul id="competitionList" class="collection with-header">
-    <li class="collection-header"><h5>Competencias Existentes</h5></li>
-  </ul>
-  
+
+<div class="row">
+  <form id="competition-edit-form" class="col s12">
+    <div class="row">
+      <div class="input-field col s12 m6">
+        <select id="competitionSelectEdit"></select>
+        <label>Competencia</label>
+      </div>
+      <div class="input-field col s12 m6">
+        <input id="competitionNewName" type="text">
+        <label for="competitionNewName">Nuevo nombre</label>
+      </div>
+      <div class="col s12">
+        <button class="btn waves-effect" type="submit">Actualizar competencia</button>
+      </div>
+    </div>
+  </form>
+</div>
+
+<ul id="competitionList" class="collection with-header">
+  <li class="collection-header"><h5>Competencias Existentes</h5></li>
+</ul>

--- a/views/admin/partials/owners.ejs
+++ b/views/admin/partials/owners.ejs
@@ -1,6 +1,47 @@
 <div class="row">
-  <div class="col s12">
-    <h5>Owners Management</h5>
-    <p>Aún no se ha implementado la interfaz de administración de owners.</p>
-  </div>
+  <form id="owner-form" class="col s12">
+    <div class="row">
+      <div class="input-field col s12 m4">
+        <input id="ownerUser" name="username" type="text" required>
+        <label for="ownerUser">Username</label>
+      </div>
+      <div class="input-field col s12 m4">
+        <input id="ownerEmail" name="email" type="email" required>
+        <label for="ownerEmail">Email</label>
+      </div>
+      <div class="input-field col s12 m4">
+        <input id="ownerPassword" name="password" type="password" required>
+        <label for="ownerPassword">Contraseña</label>
+      </div>
+      <div class="col s12">
+        <button class="btn waves-effect" type="submit">Crear Owner</button>
+      </div>
+    </div>
+  </form>
 </div>
+
+<div class="row">
+  <form id="owner-edit-form" class="col s12">
+    <div class="row">
+      <div class="input-field col s12 m4">
+        <select id="ownerSelectEdit"></select>
+        <label>Owner</label>
+      </div>
+      <div class="input-field col s12 m4">
+        <input id="ownerEditUsername" type="text">
+        <label for="ownerEditUsername">Nuevo username</label>
+      </div>
+      <div class="input-field col s12 m4">
+        <input id="ownerEditEmail" type="email">
+        <label for="ownerEditEmail">Nuevo email</label>
+      </div>
+      <div class="col s12">
+        <button class="btn waves-effect" type="submit">Actualizar Owner</button>
+      </div>
+    </div>
+  </form>
+</div>
+
+<ul id="ownerList" class="collection with-header">
+  <li class="collection-header"><h5>Owners Existentes</h5></li>
+</ul>

--- a/views/admin/partials/pencas.ejs
+++ b/views/admin/partials/pencas.ejs
@@ -28,8 +28,37 @@
     </div>
   </form>
 </div>
-  
-  <ul id="pencaList" class="collection with-header">
-    <li class="collection-header"><h5>Pencas existentes</h5></li>
-  </ul>
-  
+
+<div class="row">
+  <form id="penca-edit-form" class="col s12">
+    <div class="row">
+      <div class="input-field col s12 m4">
+        <select id="editPencaSelect"></select>
+        <label>Penca</label>
+      </div>
+      <div class="input-field col s12 m4">
+        <input id="editPencaName" type="text">
+        <label for="editPencaName">Nuevo nombre</label>
+      </div>
+      <div class="input-field col s12 m4">
+        <input id="editPencaLimit" type="number" min="1">
+        <label for="editPencaLimit">Nuevo límite</label>
+      </div>
+      <div class="input-field col s12 m4">
+        <select id="editPencaOwner"></select>
+        <label>Owner</label>
+      </div>
+      <div class="input-field col s12 m4">
+        <select id="editPencaCompetition"></select>
+        <label>Competencia</label>
+      </div>
+      <div class="col s12">
+        <button class="btn waves-effect" type="submit">Actualizar Penca</button>
+      </div>
+    </div>
+  </form>
+</div>
+
+<ul id="pencaList" class="collection with-header">
+  <li class="collection-header"><h5>Pencas existentes</h5></li>
+</ul>


### PR DESCRIPTION
## Summary
- redesign owner admin with create and edit forms
- allow editing competitions and pencas
- update admin.js to handle new forms and delete owners

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686458aeffd08325a11ea26cf1737681