### PR TITLE
Add React frontend scaffold with Vite

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ El valor `MAX_PENCAS_PER_USER` controla cuántas pencas puede integrar cada usua
 npm run dev
 ```
 
+Si modificas el frontend de React, genera los archivos estáticos con:
+
+```bash
+cd frontend && npm run build
+```
+
 Para un entorno de producción puedes utilizar `npm start`.
 
 Al iniciarse por primera vez, la aplicación comprobará que exista la base de datos
@@ -62,6 +68,7 @@ definidas en tu archivo `.env`.
 - **routes/** – rutas de la aplicación: administración, partidos, predicciones, ranking y pencas.
 - **public/** – archivos estáticos (CSS, imágenes, scripts de cliente, uploads).
 - **views/** – plantillas EJS para las vistas HTML.
+- **frontend/** – aplicación React compilada con Vite.
 - **matches.json** – datos de ejemplo de los partidos que pueden cargarse desde las rutas de administración.
 - **updateschema.js** – script auxiliar para crear o actualizar esquemas en MongoDB.
 

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+/dist

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,9 @@
+# Frontend React App
+
+Este directorio contiene una pequeña aplicación de React implementada con Vite. El formulario de inicio de sesión consume las rutas existentes del servidor Express.
+
+## Comandos
+
+- `npm install` – instala las dependencias del frontend.
+- `npm run dev` – inicia el servidor de desarrollo de Vite.
+- `npm run build` – genera los archivos estáticos en `dist/` para que Express pueda servirlos.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Penca Login</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "penca-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^4.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/frontend/src/Login.jsx
+++ b/frontend/src/Login.jsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+
+export default function Login() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    try {
+      const res = await fetch('/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+      });
+      const data = await res.json();
+      if (res.ok && data.redirectUrl) {
+        window.location.href = data.redirectUrl;
+      } else {
+        setError(data.error || 'Error');
+      }
+    } catch (err) {
+      setError('Error de red');
+    }
+  };
+
+  return (
+    <div className="container" style={{ maxWidth: '400px', marginTop: '2rem' }}>
+      <h5>Iniciar Sesión</h5>
+      <form onSubmit={handleSubmit}>
+        <div className="input-field">
+          <input id="login-username" type="text" value={username} onChange={(e) => setUsername(e.target.value)} required />
+          <label htmlFor="login-username" className="active">Nombre de usuario</label>
+        </div>
+        <div className="input-field">
+          <input id="login-password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
+          <label htmlFor="login-password" className="active">Contraseña</label>
+        </div>
+        <button className="btn waves-effect waves-light blue darken-3" type="submit" style={{ width: '100%' }}>Ingresar</button>
+      </form>
+      {error && <div className="red-text" style={{ marginTop: '1rem' }}>{error}</div>
+    </div>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import Login from './Login';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <Login />
+  </React.StrictMode>
+);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+  },
+  root: '.',
+  server: {
+    port: 5173
+  }
+});

--- a/main.js
+++ b/main.js
@@ -146,6 +146,8 @@ app.use(cacheControl);
 
 // Servir archivos estáticos
 app.use(express.static(path.join(__dirname, 'public')));
+// Archivos estáticos generados por Vite
+app.use(express.static(path.join(__dirname, 'frontend', 'dist')));
 
 app.use((req, res, next) => {
     res.locals.user = req.session.user;
@@ -160,7 +162,8 @@ app.get('/', (req, res) => {
     if (req.session.user) {
         return res.redirect('/dashboard');
     }
-    res.render('login');
+    // Enviar la aplicación React compilada
+    res.sendFile(path.join(__dirname, 'frontend', 'dist', 'index.html'));
 });
 
 app.get('/dashboard', isAuthenticated, async (req, res) => {


### PR DESCRIPTION
## Summary
- add new `frontend/` directory with a minimal React + Vite setup
- serve compiled assets from Express and render React login
- document how to build the frontend in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866a37904e4832595229e05f9fb49a4