### PR TITLE
Add Vercel build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Si modificas el frontend de React, genera los archivos estáticos con:
 cd frontend && npm run build
 ```
 
+En Vercel la compilación del frontend se realiza automáticamente durante el despliegue.
+
 Para un entorno de producción puedes utilizar `npm start`.
 
 Al iniciarse por primera vez, la aplicación comprobará que exista la base de datos

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "node main.js",
     "dev": "nodemon main.js",
     "test": "jest",
-    "build-css": "sass public/scss/style.scss public/css/style.css"
+    "build-css": "sass public/scss/style.scss public/css/style.css",
+    "vercel-build": "npm install --prefix frontend && npm run build --prefix frontend"
   },
   "dependencies": {
     "bcrypt": "^5.0.1",

--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,7 @@
       "use": "@vercel/node"
     }
   ],
+  "buildCommand": "npm run vercel-build",
   "routes": [
     { "src": "/api/(.*)", "dest": "/main.js" },
     { "src": "/login", "dest": "/main.js" },


### PR DESCRIPTION
## Summary
- compile the React frontend during Vercel deployments
- document automatic build in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686706efdc008325ada6073e95659a35