### PR TITLE
Install dev deps before tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,13 @@ Con esta estructura puedes navegar fácilmente por cada componente de la aplicac
 ## Pruebas
 
 
-Antes de ejecutar las pruebas es necesario instalar todas las dependencias,
-incluidas las de desarrollo. Ejecuta:
+Antes de ejecutar las pruebas asegúrate de instalar todas las dependencias de
+desarrollo. Para obtener una instalación reproducible puedes utilizar `npm ci`
+tanto en la raíz del proyecto como dentro de `frontend/`:
 
 ```bash
-npm install
+npm ci
+cd frontend && npm ci
 ```
 
 En entornos de integración continua puedes ejecutar el script `scripts/setup-tests.sh` o utilizar `npm ci` para garantizar instalaciones reproducibles.

--- a/scripts/setup-tests.sh
+++ b/scripts/setup-tests.sh
@@ -1,3 +1,14 @@
 #!/bin/sh
-# Installs dependencies for running tests in CI environments
-npm ci
+# Installs backend and frontend dependencies for running tests in CI
+
+set -e
+
+# Install backend dependencies only if node_modules is missing
+if [ ! -d node_modules ]; then
+  npm ci
+fi
+
+# Install frontend dev dependencies if the frontend folder exists and they aren't installed
+if [ -d frontend ]; then
+  (cd frontend && [ ! -d node_modules ] && npm ci)
+fi


### PR DESCRIPTION
## Summary
- ensure setup-tests.sh installs backend and frontend dependencies when missing
- document running `npm ci` before executing tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686706efc5b883259dfbb44c93e1f834