### PR TITLE
Add Vercel build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Si modificas el frontend de React, genera los archivos estáticos con:
 cd frontend && npm run build
 ```
 
+En Vercel la compilación del frontend se realiza automáticamente durante el despliegue con `npm run vercel-build` y la carpeta `frontend/dist` queda disponible en producción.
+
 Para un entorno de producción puedes utilizar `npm start`.
 
 Al iniciarse por primera vez, la aplicación comprobará que exista la base de datos

--- a/frontend/src/Login.jsx
+++ b/frontend/src/Login.jsx
@@ -39,7 +39,9 @@ export default function Login() {
         </div>
         <button className="btn waves-effect waves-light blue darken-3" type="submit" style={{ width: '100%' }}>Ingresar</button>
       </form>
-      {error && <div className="red-text" style={{ marginTop: '1rem' }}>{error}</div>
+      {error && (
+        <div className="red-text" style={{ marginTop: '1rem' }}>{error}</div>
+      )}
     </div>
   );
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "node main.js",
     "dev": "nodemon main.js",
     "test": "jest",
-    "build-css": "sass public/scss/style.scss public/css/style.css"
+    "build-css": "sass public/scss/style.scss public/css/style.css",
+    "vercel-build": "npm install --prefix frontend && npm run build --prefix frontend"
   },
   "dependencies": {
     "bcrypt": "^5.0.1",

--- a/vercel.json
+++ b/vercel.json
@@ -3,9 +3,13 @@
   "builds": [
     {
       "src": "main.js",
-      "use": "@vercel/node"
+      "use": "@vercel/node",
+      "config": {
+        "includeFiles": "frontend/dist/**"
+      }
     }
   ],
+  "buildCommand": "npm run vercel-build",
   "routes": [
     { "src": "/api/(.*)", "dest": "/main.js" },
     { "src": "/login", "dest": "/main.js" },


### PR DESCRIPTION
## Summary
- compile the React frontend during Vercel deployments
- include the compiled files in the serverless function
- document automatic build in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686706efdc008325ada6073e95659a35