### PR TITLE
Start React dashboard

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,10 +3,15 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Penca Login</title>
+    <title>Penca App</title>
+    <link rel="stylesheet" href="/css/materialize.min.css" />
+    <link rel="stylesheet" href="/css/style.css" />
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
+    <script src="/js/materialize.min.js"></script>
   </body>
 </html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.4.0"
   },
   "devDependencies": {
     "vite": "^4.0.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,14 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import Login from './Login';
+import Dashboard from './Dashboard';
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Login />} />
+        <Route path="/dashboard" element={<Dashboard />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+
+export default function Dashboard() {
+  const [pencas, setPencas] = useState([]);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/dashboard');
+        if (res.ok) {
+          const data = await res.json();
+          setPencas(data.pencas || []);
+        }
+      } catch (err) {
+        console.error('dashboard fetch error', err);
+      }
+    }
+    load();
+  }, []);
+
+  return (
+    <div className="container" style={{ marginTop: '2rem' }}>
+      <h5>Mis Pencas</h5>
+      {pencas.length === 0 && <p>No est\u00e1s en ninguna penca.</p>}
+      {pencas.map((p) => (
+        <div key={p._id} className="card">
+          <div className="card-content">
+            <span className="card-title">{p.name}</span>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/Login.jsx
+++ b/frontend/src/Login.jsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 export default function Login() {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
+  const navigate = useNavigate();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -16,7 +18,11 @@ export default function Login() {
       });
       const data = await res.json();
       if (res.ok && data.redirectUrl) {
-        window.location.href = data.redirectUrl;
+        if (data.redirectUrl === '/dashboard') {
+          navigate('/dashboard');
+        } else {
+          window.location.href = data.redirectUrl;
+        }
       } else {
         setError(data.error || 'Error');
       }

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import Login from './Login';
+import App from './App';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <Login />
+    <App />
   </React.StrictMode>
 );

--- a/main.js
+++ b/main.js
@@ -171,13 +171,23 @@ app.get('/dashboard', isAuthenticated, async (req, res) => {
     if (user.role === 'admin') {
         return res.redirect('/admin/edit');
     }
-    let pencas = [];
-    try {
-        pencas = await Penca.find({ participants: user._id }).select('name _id');
-    } catch (err) {
-        console.error('dashboard pencas error', err);
+    // Enviar la aplicación React para el dashboard
+    res.sendFile(path.join(__dirname, 'frontend', 'dist', 'index.html'));
+});
+
+// Datos para el dashboard en React
+app.get('/api/dashboard', isAuthenticated, async (req, res) => {
+    const { user } = req.session;
+    if (user.role === 'admin') {
+        return res.status(403).json({ error: 'Admins must use /admin/edit' });
     }
-    res.render('dashboard', { user, pencas, debug: DEBUG });
+    try {
+        const pencas = await Penca.find({ participants: user._id }).select('name _id');
+        res.json({ user: { username: user.username, role: user.role }, pencas });
+    } catch (err) {
+        console.error('dashboard api error', err);
+        res.status(500).json({ error: 'Error retrieving dashboard data' });
+    }
 });
 
 app.post('/login', async (req, res) => {


### PR DESCRIPTION
## Summary
- prepare React entrypoint for routing
- serve React app on `/dashboard`
- expose `/api/dashboard` with penca data
- add simple Dashboard component
- wire login to React Router and include styles

## Testing
- `npm install --prefix frontend` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686815edec6c8325ab99069f81fcc01e