### PR TITLE
Add fixture upload to admin panel

### DIFF
--- a/frontend/src/Admin.jsx
+++ b/frontend/src/Admin.jsx
@@ -6,6 +6,7 @@ export default function Admin() {
   const [pencas, setPencas] = useState([]);
 
   const [newCompetition, setNewCompetition] = useState('');
+  const [competitionFile, setCompetitionFile] = useState(null);
   const [ownerForm, setOwnerForm] = useState({ username: '', password: '', email: '' });
   const [pencaForm, setPencaForm] = useState({ name: '', owner: '', competition: '' });
 
@@ -47,13 +48,16 @@ export default function Admin() {
   async function createCompetition(e) {
     e.preventDefault();
     try {
+      const data = new FormData();
+      data.append('name', newCompetition);
+      if (competitionFile) data.append('fixture', competitionFile);
       const res = await fetch('/admin/competitions', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: newCompetition })
+        body: data
       });
       if (res.ok) {
         setNewCompetition('');
+        setCompetitionFile(null);
         loadCompetitions();
       }
     } catch (err) {
@@ -131,16 +135,21 @@ export default function Admin() {
     }
   }
 
+  const [pencaFile, setPencaFile] = useState(null);
+
   async function createPenca(e) {
     e.preventDefault();
     try {
+      const data = new FormData();
+      Object.entries(pencaForm).forEach(([k, v]) => data.append(k, v));
+      if (pencaFile) data.append('fixture', pencaFile);
       const res = await fetch('/admin/pencas', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(pencaForm)
+        body: data
       });
       if (res.ok) {
         setPencaForm({ name: '', owner: '', competition: '' });
+        setPencaFile(null);
         loadPencas();
       }
     } catch (err) {
@@ -183,6 +192,7 @@ export default function Admin() {
         <h6>Competencias</h6>
         <form onSubmit={createCompetition} style={{ marginBottom: '1rem' }}>
           <input type="text" value={newCompetition} onChange={e => setNewCompetition(e.target.value)} placeholder="Nombre" required />
+          <input type="file" accept=".json" onChange={e => setCompetitionFile(e.target.files[0])} style={{ marginLeft: '10px' }} />
           <button className="btn" type="submit" style={{ marginLeft: '10px' }}>Crear</button>
         </form>
         <ul className="collection">
@@ -232,6 +242,7 @@ export default function Admin() {
               <option key={c._id} value={c.name}>{c.name}</option>
             ))}
           </select>
+          <input type="file" accept=".json" onChange={e => setPencaFile(e.target.files[0])} style={{ marginLeft: '10px' }} />
           <button className="btn" type="submit" style={{ marginLeft: '10px' }}>Crear</button>
         </form>
         <ul className="collection">

--- a/worldcup2026_placeholder.json
+++ b/worldcup2026_placeholder.json
@@ -1,0 +1,963 @@
+[
+  {
+    "date": "2026-06-08",
+    "time": "12:00",
+    "team1": "A1",
+    "team2": "A2",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo A",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-06-09",
+    "time": "12:00",
+    "team1": "A3",
+    "team2": "A4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo A",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-06-10",
+    "time": "12:00",
+    "team1": "A1",
+    "team2": "A3",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo A",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-06-11",
+    "time": "12:00",
+    "team1": "A2",
+    "team2": "A4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo A",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-06-12",
+    "time": "12:00",
+    "team1": "A1",
+    "team2": "A4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo A",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-06-13",
+    "time": "12:00",
+    "team1": "A2",
+    "team2": "A3",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo A",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-06-14",
+    "time": "12:00",
+    "team1": "B1",
+    "team2": "B2",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo B",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-06-15",
+    "time": "12:00",
+    "team1": "B3",
+    "team2": "B4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo B",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-06-16",
+    "time": "12:00",
+    "team1": "B1",
+    "team2": "B3",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo B",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-06-17",
+    "time": "12:00",
+    "team1": "B2",
+    "team2": "B4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo B",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-06-18",
+    "time": "12:00",
+    "team1": "B1",
+    "team2": "B4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo B",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-06-19",
+    "time": "12:00",
+    "team1": "B2",
+    "team2": "B3",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo B",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-06-20",
+    "time": "12:00",
+    "team1": "C1",
+    "team2": "C2",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo C",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-06-21",
+    "time": "12:00",
+    "team1": "C3",
+    "team2": "C4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo C",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-06-22",
+    "time": "12:00",
+    "team1": "C1",
+    "team2": "C3",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo C",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-06-23",
+    "time": "12:00",
+    "team1": "C2",
+    "team2": "C4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo C",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-06-24",
+    "time": "12:00",
+    "team1": "C1",
+    "team2": "C4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo C",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-06-25",
+    "time": "12:00",
+    "team1": "C2",
+    "team2": "C3",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo C",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-06-26",
+    "time": "12:00",
+    "team1": "D1",
+    "team2": "D2",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo D",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-06-27",
+    "time": "12:00",
+    "team1": "D3",
+    "team2": "D4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo D",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-06-28",
+    "time": "12:00",
+    "team1": "D1",
+    "team2": "D3",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo D",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-06-29",
+    "time": "12:00",
+    "team1": "D2",
+    "team2": "D4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo D",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-06-30",
+    "time": "12:00",
+    "team1": "D1",
+    "team2": "D4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo D",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-01",
+    "time": "12:00",
+    "team1": "D2",
+    "team2": "D3",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo D",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-02",
+    "time": "12:00",
+    "team1": "E1",
+    "team2": "E2",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo E",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-03",
+    "time": "12:00",
+    "team1": "E3",
+    "team2": "E4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo E",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-04",
+    "time": "12:00",
+    "team1": "E1",
+    "team2": "E3",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo E",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-05",
+    "time": "12:00",
+    "team1": "E2",
+    "team2": "E4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo E",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-06",
+    "time": "12:00",
+    "team1": "E1",
+    "team2": "E4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo E",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-07",
+    "time": "12:00",
+    "team1": "E2",
+    "team2": "E3",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo E",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-08",
+    "time": "12:00",
+    "team1": "F1",
+    "team2": "F2",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo F",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-09",
+    "time": "12:00",
+    "team1": "F3",
+    "team2": "F4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo F",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-10",
+    "time": "12:00",
+    "team1": "F1",
+    "team2": "F3",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo F",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-11",
+    "time": "12:00",
+    "team1": "F2",
+    "team2": "F4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo F",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-12",
+    "time": "12:00",
+    "team1": "F1",
+    "team2": "F4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo F",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-13",
+    "time": "12:00",
+    "team1": "F2",
+    "team2": "F3",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo F",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-14",
+    "time": "12:00",
+    "team1": "G1",
+    "team2": "G2",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo G",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-15",
+    "time": "12:00",
+    "team1": "G3",
+    "team2": "G4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo G",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-16",
+    "time": "12:00",
+    "team1": "G1",
+    "team2": "G3",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo G",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-17",
+    "time": "12:00",
+    "team1": "G2",
+    "team2": "G4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo G",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-18",
+    "time": "12:00",
+    "team1": "G1",
+    "team2": "G4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo G",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-19",
+    "time": "12:00",
+    "team1": "G2",
+    "team2": "G3",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo G",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-20",
+    "time": "12:00",
+    "team1": "H1",
+    "team2": "H2",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo H",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-21",
+    "time": "12:00",
+    "team1": "H3",
+    "team2": "H4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo H",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-22",
+    "time": "12:00",
+    "team1": "H1",
+    "team2": "H3",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo H",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-23",
+    "time": "12:00",
+    "team1": "H2",
+    "team2": "H4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo H",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-24",
+    "time": "12:00",
+    "team1": "H1",
+    "team2": "H4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo H",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-25",
+    "time": "12:00",
+    "team1": "H2",
+    "team2": "H3",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo H",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-26",
+    "time": "12:00",
+    "team1": "I1",
+    "team2": "I2",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo I",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-27",
+    "time": "12:00",
+    "team1": "I3",
+    "team2": "I4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo I",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-28",
+    "time": "12:00",
+    "team1": "I1",
+    "team2": "I3",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo I",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-29",
+    "time": "12:00",
+    "team1": "I2",
+    "team2": "I4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo I",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-30",
+    "time": "12:00",
+    "team1": "I1",
+    "team2": "I4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo I",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-07-31",
+    "time": "12:00",
+    "team1": "I2",
+    "team2": "I3",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo I",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-01",
+    "time": "12:00",
+    "team1": "J1",
+    "team2": "J2",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo J",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-02",
+    "time": "12:00",
+    "team1": "J3",
+    "team2": "J4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo J",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-03",
+    "time": "12:00",
+    "team1": "J1",
+    "team2": "J3",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo J",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-04",
+    "time": "12:00",
+    "team1": "J2",
+    "team2": "J4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo J",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-05",
+    "time": "12:00",
+    "team1": "J1",
+    "team2": "J4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo J",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-06",
+    "time": "12:00",
+    "team1": "J2",
+    "team2": "J3",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo J",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-07",
+    "time": "12:00",
+    "team1": "K1",
+    "team2": "K2",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo K",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-08",
+    "time": "12:00",
+    "team1": "K3",
+    "team2": "K4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo K",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-09",
+    "time": "12:00",
+    "team1": "K1",
+    "team2": "K3",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo K",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-10",
+    "time": "12:00",
+    "team1": "K2",
+    "team2": "K4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo K",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-11",
+    "time": "12:00",
+    "team1": "K1",
+    "team2": "K4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo K",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-12",
+    "time": "12:00",
+    "team1": "K2",
+    "team2": "K3",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo K",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-13",
+    "time": "12:00",
+    "team1": "L1",
+    "team2": "L2",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo L",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-14",
+    "time": "12:00",
+    "team1": "L3",
+    "team2": "L4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo L",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-15",
+    "time": "12:00",
+    "team1": "L1",
+    "team2": "L3",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo L",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-16",
+    "time": "12:00",
+    "team1": "L2",
+    "team2": "L4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo L",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-17",
+    "time": "12:00",
+    "team1": "L1",
+    "team2": "L4",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo L",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-18",
+    "time": "12:00",
+    "team1": "L2",
+    "team2": "L3",
+    "competition": "Mundial 2026",
+    "group_name": "Grupo L",
+    "series": "Fase de grupos",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-19",
+    "time": "18:00",
+    "team1": "A1",
+    "team2": "B2",
+    "competition": "Mundial 2026",
+    "group_name": "Ronda de 32",
+    "series": "Eliminatorias",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-20",
+    "time": "18:00",
+    "team1": "C1",
+    "team2": "D2",
+    "competition": "Mundial 2026",
+    "group_name": "Ronda de 32",
+    "series": "Eliminatorias",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-21",
+    "time": "18:00",
+    "team1": "E1",
+    "team2": "F2",
+    "competition": "Mundial 2026",
+    "group_name": "Ronda de 32",
+    "series": "Eliminatorias",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-22",
+    "time": "18:00",
+    "team1": "G1",
+    "team2": "H2",
+    "competition": "Mundial 2026",
+    "group_name": "Ronda de 32",
+    "series": "Eliminatorias",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-23",
+    "time": "18:00",
+    "team1": "I1",
+    "team2": "J2",
+    "competition": "Mundial 2026",
+    "group_name": "Ronda de 32",
+    "series": "Eliminatorias",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-24",
+    "time": "18:00",
+    "team1": "K1",
+    "team2": "L2",
+    "competition": "Mundial 2026",
+    "group_name": "Ronda de 32",
+    "series": "Eliminatorias",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-25",
+    "time": "18:00",
+    "team1": "B1",
+    "team2": "A2",
+    "competition": "Mundial 2026",
+    "group_name": "Ronda de 32",
+    "series": "Eliminatorias",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-26",
+    "time": "18:00",
+    "team1": "D1",
+    "team2": "C2",
+    "competition": "Mundial 2026",
+    "group_name": "Ronda de 32",
+    "series": "Eliminatorias",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-27",
+    "time": "18:00",
+    "team1": "F1",
+    "team2": "E2",
+    "competition": "Mundial 2026",
+    "group_name": "Ronda de 32",
+    "series": "Eliminatorias",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-28",
+    "time": "18:00",
+    "team1": "H1",
+    "team2": "G2",
+    "competition": "Mundial 2026",
+    "group_name": "Ronda de 32",
+    "series": "Eliminatorias",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-29",
+    "time": "18:00",
+    "team1": "J1",
+    "team2": "I2",
+    "competition": "Mundial 2026",
+    "group_name": "Ronda de 32",
+    "series": "Eliminatorias",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-30",
+    "time": "18:00",
+    "team1": "L1",
+    "team2": "K2",
+    "competition": "Mundial 2026",
+    "group_name": "Ronda de 32",
+    "series": "Eliminatorias",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-08-31",
+    "time": "18:00",
+    "team1": "A3",
+    "team2": "C3",
+    "competition": "Mundial 2026",
+    "group_name": "Ronda de 32",
+    "series": "Eliminatorias",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-09-01",
+    "time": "18:00",
+    "team1": "E3",
+    "team2": "G3",
+    "competition": "Mundial 2026",
+    "group_name": "Ronda de 32",
+    "series": "Eliminatorias",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-09-02",
+    "time": "18:00",
+    "team1": "I3",
+    "team2": "K3",
+    "competition": "Mundial 2026",
+    "group_name": "Ronda de 32",
+    "series": "Eliminatorias",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-09-03",
+    "time": "18:00",
+    "team1": "B3",
+    "team2": "D3",
+    "competition": "Mundial 2026",
+    "group_name": "Ronda de 32",
+    "series": "Eliminatorias",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-09-04",
+    "time": "18:00",
+    "team1": "Ganador R32-1",
+    "team2": "Ganador R32-2",
+    "competition": "Mundial 2026",
+    "group_name": "Cuartos de final",
+    "series": "Eliminatorias",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-09-05",
+    "time": "18:00",
+    "team1": "Ganador R32-3",
+    "team2": "Ganador R32-4",
+    "competition": "Mundial 2026",
+    "group_name": "Cuartos de final",
+    "series": "Eliminatorias",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-09-06",
+    "time": "18:00",
+    "team1": "Ganador R32-5",
+    "team2": "Ganador R32-6",
+    "competition": "Mundial 2026",
+    "group_name": "Cuartos de final",
+    "series": "Eliminatorias",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-09-07",
+    "time": "18:00",
+    "team1": "Ganador R32-7",
+    "team2": "Ganador R32-8",
+    "competition": "Mundial 2026",
+    "group_name": "Cuartos de final",
+    "series": "Eliminatorias",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-09-08",
+    "time": "18:00",
+    "team1": "Ganador QF1",
+    "team2": "Ganador QF2",
+    "competition": "Mundial 2026",
+    "group_name": "Semifinal",
+    "series": "Eliminatorias",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-09-09",
+    "time": "18:00",
+    "team1": "Ganador QF3",
+    "team2": "Ganador QF4",
+    "competition": "Mundial 2026",
+    "group_name": "Semifinal",
+    "series": "Eliminatorias",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-09-10",
+    "time": "18:00",
+    "team1": "Perdedor SF1",
+    "team2": "Perdedor SF2",
+    "competition": "Mundial 2026",
+    "group_name": "Tercer puesto",
+    "series": "Eliminatorias",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  },
+  {
+    "date": "2026-09-11",
+    "time": "18:00",
+    "team1": "Ganador SF1",
+    "team2": "Ganador SF2",
+    "competition": "Mundial 2026",
+    "group_name": "Final",
+    "series": "Eliminatorias",
+    "tournament": "Copa Mundial de la FIFA 2026"
+  }
+]
+


### PR DESCRIPTION
## Summary
- support uploading JSON fixture when creating competitions or pencas
- provide sample `worldcup2026_placeholder.json`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874567f84e88325bf6918a6a174114d