### PR TITLE
Sort ranking scores before returning

### DIFF
--- a/routes/ranking.js
+++ b/routes/ranking.js
@@ -82,6 +82,7 @@ async function calculateScores(pencaId, competition) {
         });
     }
 
+    scores.sort((a, b) => b.score - a.score);
     return scores;
 }
 


### PR DESCRIPTION
## Summary
- ensure scores in ranking route are sorted in descending order

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68745d2494c8832595c180e3303b5ed7