### PR TITLE
Add match editing endpoint and admin UI

### DIFF
--- a/frontend/src/Admin.jsx
+++ b/frontend/src/Admin.jsx
@@ -4,6 +4,7 @@ export default function Admin() {
   const [competitions, setCompetitions] = useState([]);
   const [owners, setOwners] = useState([]);
   const [pencas, setPencas] = useState([]);
+  const [matches, setMatches] = useState([]);
 
   const [newCompetition, setNewCompetition] = useState('');
   const [competitionFile, setCompetitionFile] = useState(null);
@@ -15,7 +16,7 @@ export default function Admin() {
   }, []);
 
   async function loadAll() {
-    await Promise.all([loadCompetitions(), loadOwners(), loadPencas()]);
+    await Promise.all([loadCompetitions(), loadOwners(), loadPencas(), loadMatches()]);
   }
 
   async function loadCompetitions() {
@@ -42,6 +43,15 @@ export default function Admin() {
       if (res.ok) setPencas(await res.json());
     } catch (err) {
       console.error('load pencas error', err);
+    }
+  }
+
+  async function loadMatches() {
+    try {
+      const res = await fetch('/matches');
+      if (res.ok) setMatches(await res.json());
+    } catch (err) {
+      console.error('load matches error', err);
     }
   }
 
@@ -184,6 +194,24 @@ export default function Admin() {
     }
   }
 
+  const updateMatchField = (id, field, value) => {
+    setMatches(ms => ms.map(m => m._id === id ? { ...m, [field]: value } : m));
+  };
+
+  async function saveMatch(match) {
+    try {
+      const { team1, team2, date, time } = match;
+      const res = await fetch(`/matches/${match._id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ team1, team2, date, time })
+      });
+      if (res.ok) loadMatches();
+    } catch (err) {
+      console.error('update match error', err);
+    }
+  }
+
   return (
     <div className="container" style={{ marginTop: '2rem' }}>
       <h5>Administración</h5>
@@ -262,9 +290,24 @@ export default function Admin() {
               <a href="#" className="secondary-content" onClick={e => { e.preventDefault(); savePenca(p); }}>💾</a>
               <a href="#" className="secondary-content red-text" style={{ marginLeft: '1rem' }} onClick={e => { e.preventDefault(); deletePenca(p._id); }}>✖</a>
             </li>
-          ))}
-        </ul>
-      </section>
-    </div>
+      ))}
+      </ul>
+    </section>
+
+    <section style={{ marginTop: '2rem' }}>
+      <h6>Matches</h6>
+      <ul className="collection">
+        {matches.map(m => (
+          <li key={m._id} className="collection-item">
+            <input type="text" value={m.team1 || ''} onChange={e => updateMatchField(m._id, 'team1', e.target.value)} />
+            <input type="text" value={m.team2 || ''} onChange={e => updateMatchField(m._id, 'team2', e.target.value)} style={{ marginLeft: '10px' }} />
+            <input type="date" value={m.date || ''} onChange={e => updateMatchField(m._id, 'date', e.target.value)} style={{ marginLeft: '10px' }} />
+            <input type="time" value={m.time || ''} onChange={e => updateMatchField(m._id, 'time', e.target.value)} style={{ marginLeft: '10px' }} />
+            <a href="#" className="secondary-content" onClick={e => { e.preventDefault(); saveMatch(m); }}>💾</a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  </div>
   );
 }

--- a/routes/matches.js
+++ b/routes/matches.js
@@ -29,4 +29,22 @@ router.post('/:id', isAdmin, async (req, res) => {
     }
 });
 
+router.put('/:id', isAdmin, async (req, res) => {
+    try {
+        const { team1, team2, date, time } = req.body;
+        const match = await Match.findById(req.params.id);
+        if (!match) {
+            return res.status(404).json({ error: 'Match not found' });
+        }
+        if (team1 !== undefined) match.team1 = team1;
+        if (team2 !== undefined) match.team2 = team2;
+        if (date !== undefined) match.date = date;
+        if (time !== undefined) match.time = time;
+        await match.save();
+        res.json({ message: 'Match updated' });
+    } catch (err) {
+        res.status(500).json({ error: 'Error updating match' });
+    }
+});
+
 module.exports = router;

--- a/tests/matches.test.js
+++ b/tests/matches.test.js
@@ -34,4 +34,25 @@ describe('Match Routes', () => {
     expect(res.body.message).toBe('Match result updated');
     expect(save).toHaveBeenCalled();
   });
+
+  it('updates match info', async () => {
+    const match = { _id: '1', save: jest.fn().mockResolvedValue(true) };
+    Match.findById.mockResolvedValue(match);
+
+    const app = express();
+    app.use(express.json());
+    app.use('/matches', matchesRouter);
+
+    const res = await request(app)
+      .put('/matches/1')
+      .send({ team1: 'A', team2: 'B', date: '2024-07-01', time: '20:00' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Match updated');
+    expect(match.team1).toBe('A');
+    expect(match.team2).toBe('B');
+    expect(match.date).toBe('2024-07-01');
+    expect(match.time).toBe('20:00');
+    expect(match.save).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- support admin editing of match information
- expose PUT `/matches/:id` API to update team names and schedule
- display and edit matches in Admin dashboard
- add test for new endpoint

## Testing
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68745d23a5d48325ae9292c4cded266b