### PR TITLE
Add bracket utilities and tests

### DIFF
--- a/bracket.js
+++ b/bracket.js
@@ -1,0 +1,51 @@
+const Match = require('./models/Match');
+
+function calculateGroupStandings(matches) {
+  const standings = {};
+  for (const m of matches) {
+    const { team1, team2, result1 = 0, result2 = 0 } = m;
+    if (!standings[team1]) standings[team1] = { team: team1, points: 0, goalsFor: 0, goalsAgainst: 0 };
+    if (!standings[team2]) standings[team2] = { team: team2, points: 0, goalsFor: 0, goalsAgainst: 0 };
+    standings[team1].goalsFor += result1;
+    standings[team1].goalsAgainst += result2;
+    standings[team2].goalsFor += result2;
+    standings[team2].goalsAgainst += result1;
+    if (result1 > result2) {
+      standings[team1].points += 3;
+    } else if (result1 < result2) {
+      standings[team2].points += 3;
+    } else {
+      standings[team1].points += 1;
+      standings[team2].points += 1;
+    }
+  }
+  const arr = Object.values(standings);
+  for (const s of arr) {
+    s.goalDifference = s.goalsFor - s.goalsAgainst;
+  }
+  arr.sort((a,b) => b.points - a.points || b.goalDifference - a.goalDifference || b.goalsFor - a.goalsFor);
+  return arr;
+}
+
+async function updateEliminationMatches(groupStandings) {
+  const quarterMatches = await Match.find({ group_name: 'Cuartos de final' });
+  const map = {};
+  for (const [group, table] of Object.entries(groupStandings)) {
+    if (table[0]) map[`Ganador ${group}`] = table[0].team;
+    if (table[1]) map[`Segundo ${group}`] = table[1].team;
+  }
+  const updated = [];
+  for (const match of quarterMatches) {
+    const newTeam1 = map[match.team1] || match.team1;
+    const newTeam2 = map[match.team2] || match.team2;
+    if (newTeam1 !== match.team1 || newTeam2 !== match.team2) {
+      await Match.updateOne({ _id: match._id }, { team1: newTeam1, team2: newTeam2 });
+      updated.push({ ...match, team1: newTeam1, team2: newTeam2 });
+    } else {
+      updated.push(match);
+    }
+  }
+  return updated;
+}
+
+module.exports = { calculateGroupStandings, updateEliminationMatches };

--- a/tests/bracket.test.js
+++ b/tests/bracket.test.js
@@ -1,0 +1,53 @@
+const Match = require('../models/Match');
+
+jest.mock('../models/Match', () => ({
+  find: jest.fn(),
+  updateOne: jest.fn()
+}));
+
+const { calculateGroupStandings, updateEliminationMatches } = require('../bracket');
+
+describe('calculateGroupStandings', () => {
+  it('orders teams by points, goal difference and goals for', () => {
+    const matches = [
+      { team1: 'A', team2: 'B', result1: 1, result2: 0 },
+      { team1: 'C', team2: 'D', result1: 0, result2: 0 },
+      { team1: 'A', team2: 'C', result1: 2, result2: 1 },
+      { team1: 'B', team2: 'D', result1: 0, result2: 1 },
+      { team1: 'A', team2: 'D', result1: 1, result2: 1 },
+      { team1: 'B', team2: 'C', result1: 3, result2: 2 }
+    ];
+
+    const standings = calculateGroupStandings(matches);
+    const order = standings.map(s => s.team);
+    expect(order).toEqual(['A', 'D', 'B', 'C']);
+  });
+});
+
+describe('updateEliminationMatches', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('updates quarter finals based on group standings', async () => {
+    const quarter = [
+      { _id: 'm1', team1: 'Ganador A', team2: 'Segundo B' },
+      { _id: 'm2', team1: 'Ganador B', team2: 'Segundo A' }
+    ];
+    Match.find.mockResolvedValue(quarter);
+
+    const standings = {
+      A: [{ team: 'A1' }, { team: 'A2' }],
+      B: [{ team: 'B1' }, { team: 'B2' }]
+    };
+
+    const updated = await updateEliminationMatches(standings);
+
+    expect(Match.find).toHaveBeenCalledWith({ group_name: 'Cuartos de final' });
+    expect(Match.updateOne).toHaveBeenCalledTimes(2);
+    expect(Match.updateOne).toHaveBeenCalledWith({ _id: 'm1' }, { team1: 'A1', team2: 'B2' });
+    expect(Match.updateOne).toHaveBeenCalledWith({ _id: 'm2' }, { team1: 'B1', team2: 'A2' });
+    expect(updated).toEqual([
+      { _id: 'm1', team1: 'A1', team2: 'B2' },
+      { _id: 'm2', team1: 'B1', team2: 'A2' }
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add bracket utilities to calculate standings and update matches
- test calculateGroupStandings sorting logic
- test updateEliminationMatches updates quarter finals

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874611607408325ba6a31f152d6596f