### PR TITLE
Add Google 2025 theme

### DIFF
--- a/frontend/src/Login.jsx
+++ b/frontend/src/Login.jsx
@@ -32,7 +32,7 @@ export default function Login() {
   };
 
   return (
-    <div className="container" style={{ maxWidth: '400px', marginTop: '2rem' }}>
+    <div className="login-container card">
       <h5>Iniciar Sesión</h5>
       <form onSubmit={handleSubmit}>
         <div className="input-field">
@@ -43,7 +43,7 @@ export default function Login() {
           <input id="login-password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
           <label htmlFor="login-password" className="active">Contraseña</label>
         </div>
-        <button className="btn" type="submit" style={{ width: '100%' }}>Ingresar</button>
+        <button className="btn" type="submit">Ingresar</button>
       </form>
       {error && (
         <div className="red-text" style={{ marginTop: '1rem' }}>{error}</div>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,8 +1,8 @@
 /* === General Layout === */
 body {
     font-family: 'Roboto', sans-serif;
-    background: #f9f9f9;
-    color: #444;
+    background: #f5f5f5;
+    color: #000;
     display: flex;
     flex-direction: column;
     min-height: 100vh;
@@ -90,11 +90,11 @@ footer {
 
 /* === Match Cards === */
 .match-card {
-    border-radius: 10px;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     margin-bottom: 20px;
     padding: 15px;
-    background: #fff;
+    background: #ffffff;
     transition: border 0.3s ease;
 }
 
@@ -149,13 +149,14 @@ footer {
 
 /* === Buttons & Tabs === */
 .btn {
-    background-color: #ffd100;
-    border-radius: 25px;
-    transition: all 0.3s ease;
+    background-color: #6200ee;
+    color: #ffffff;
+    border-radius: 8px;
+    transition: background-color 0.3s ease;
 }
 
 .btn:hover {
-    background-color: #e6b800;
+    background-color: #5800d6;
 }
 
 .tabs .tab a {
@@ -199,9 +200,9 @@ footer {
     max-width: 400px;
     margin: 100px auto 50px auto;
     padding: 30px;
-    background: #fff;
-    border-radius: 10px;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+    background: #ffffff;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .login-container h5 {
@@ -346,4 +347,17 @@ footer {
     .collection .collection-item p {
         margin: 5px 0;
     }
+}
+
+/* === Theme Google 2025 === */
+.card {
+    background-color: #ffffff;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.input-field input {
+    border-radius: 8px;
+    border: 1px solid #ccc;
+    padding: 0.5rem;
 }

--- a/public/scss/style.scss
+++ b/public/scss/style.scss
@@ -7,3 +7,4 @@
 @import 'modal';
 @import 'ranking';
 @import 'utils';
+@import 'theme_google2025';

--- a/public/scss/theme_google2025.scss
+++ b/public/scss/theme_google2025.scss
@@ -1,0 +1,41 @@
+// Material style theme for 2025
+$md-primary: #6200ee;
+$md-secondary: #03dac6;
+$md-background: #f5f5f5;
+$md-surface: #ffffff;
+$md-error: #b00020;
+$md-on-primary: #ffffff;
+$md-on-secondary: #000000;
+$md-on-surface: #000000;
+$md-radius: 8px;
+$md-font: 'Roboto', sans-serif;
+
+body {
+  font-family: $md-font;
+  background-color: $md-background;
+  color: $md-on-surface;
+}
+
+.btn {
+  background-color: $md-primary;
+  color: $md-on-primary;
+  border-radius: $md-radius;
+  transition: background-color 0.3s ease;
+}
+.btn:hover {
+  background-color: darken($md-primary, 10%);
+}
+
+.match-card,
+.login-container,
+.card {
+  background-color: $md-surface;
+  border-radius: $md-radius;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.input-field input {
+  border-radius: $md-radius;
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- add new Google Material-inspired SCSS theme and import it
- tweak the login page classes for the theme
- update the compiled CSS

## Testing
- `npm run build-css` *(fails: `sass` not found)*
- `npm run build --prefix frontend` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687461154f7483259dc597e1943b280c