### PR TITLE
Add group and bracket views

### DIFF
--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react';
+import GroupTable from './GroupTable';
+import EliminationBracket from './EliminationBracket';
 
 export default function Dashboard() {
   const [user, setUser] = useState(null);
@@ -10,6 +12,8 @@ export default function Dashboard() {
   const [joinCode, setJoinCode] = useState('');
   const [joinMsg, setJoinMsg] = useState('');
   const [ownerPencas, setOwnerPencas] = useState([]);
+  const [groups, setGroups] = useState([]);
+  const [bracket, setBracket] = useState(null);
 
   useEffect(() => {
     async function load() {
@@ -44,6 +48,24 @@ export default function Dashboard() {
       }
     }
     loadData();
+  }, [pencas]);
+
+  useEffect(() => {
+    async function loadExtras() {
+      if (!pencas.length) return;
+      const comp = pencas[0].competition;
+      try {
+        const [gRes, bRes] = await Promise.all([
+          fetch(`/groups/${encodeURIComponent(comp)}`),
+          fetch(`/bracket/${encodeURIComponent(comp)}`)
+        ]);
+        if (gRes.ok) setGroups(await gRes.json());
+        if (bRes.ok) setBracket(await bRes.json());
+      } catch (err) {
+        console.error('extra data error', err);
+      }
+    }
+    loadExtras();
   }, [pencas]);
 
   async function loadRanking(id) {
@@ -191,6 +213,20 @@ export default function Dashboard() {
           </div>
         );
       })}
+
+      {groups.length > 0 && (
+        <div style={{ marginTop: '2rem' }}>
+          <h5>Grupos</h5>
+          <GroupTable groups={groups} />
+        </div>
+      )}
+
+      {bracket && (
+        <div style={{ marginTop: '2rem' }}>
+          <h5>Eliminatorias</h5>
+          <EliminationBracket bracket={bracket} />
+        </div>
+      )}
 
       {user && user.role === 'user' && (
         <div style={{ marginTop: '2rem' }}>

--- a/frontend/src/EliminationBracket.jsx
+++ b/frontend/src/EliminationBracket.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+export default function EliminationBracket({ bracket }) {
+  if (!bracket) return null;
+  const order = ['Cuartos de final', 'Semifinales', 'Tercer puesto', 'Final'];
+  return (
+    <div>
+      {order.map(r => (
+        bracket[r] && bracket[r].length ? (
+          <div key={r} style={{ marginBottom: '1rem' }}>
+            <h6>{r}</h6>
+            {bracket[r].map(m => (
+              <div key={m._id} className="match-card">
+                <div className="match-header">
+                  <div className="team">
+                    <span className="team-name">{m.team1}</span>
+                  </div>
+                  <span className="vs">vs</span>
+                  <div className="team">
+                    <span className="team-name">{m.team2}</span>
+                  </div>
+                </div>
+                {m.result1 != null && m.result2 != null && (
+                  <div className="match-details">
+                    {m.result1} - {m.result2}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        ) : null
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/GroupTable.jsx
+++ b/frontend/src/GroupTable.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+export default function GroupTable({ groups }) {
+  if (!groups || !groups.length) return null;
+  return (
+    <div>
+      {groups.map(g => (
+        <div key={g.group} style={{ marginBottom: '1rem' }}>
+          <h6>{g.group}</h6>
+          <table className="striped">
+            <thead>
+              <tr>
+                <th>Equipo</th>
+                <th>Pts</th>
+                <th>DG</th>
+                <th>GF</th>
+              </tr>
+            </thead>
+            <tbody>
+              {g.teams
+                .sort((a, b) => b.points - a.points || b.gd - a.gd || b.gf - a.gf)
+                .map(t => (
+                  <tr key={t.team}>
+                    <td>{t.team}</td>
+                    <td>{t.points}</td>
+                    <td>{t.gd}</td>
+                    <td>{t.gf}</td>
+                  </tr>
+                ))}
+            </tbody>
+          </table>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/main.js
+++ b/main.js
@@ -282,6 +282,8 @@ app.get('/avatar/:username', async (req, res) => {
 app.use('/matches', isAuthenticated, require('./routes/matches'));
 app.use('/predictions', isAuthenticated, require('./routes/predictions'));
 app.use('/ranking', isAuthenticated, require('./routes/ranking'));
+app.use('/groups', isAuthenticated, require('./routes/groups').router);
+app.use('/bracket', isAuthenticated, require('./routes/bracket'));
 app.use('/pencas', isAuthenticated, pencaRouter);
 app.use('/admin', adminRouter);
 

--- a/routes/groups.js
+++ b/routes/groups.js
@@ -1,0 +1,54 @@
+const express = require('express');
+const router = express.Router();
+const Match = require('../models/Match');
+
+function calculateGroupStandings(matches) {
+  const groups = {};
+  for (const m of matches) {
+    if (!/^Grupo/i.test(m.group_name)) continue;
+    const g = m.group_name;
+    groups[g] = groups[g] || {};
+    groups[g][m.team1] = groups[g][m.team1] || { team: m.team1, points: 0, gf: 0, ga: 0 };
+    groups[g][m.team2] = groups[g][m.team2] || { team: m.team2, points: 0, gf: 0, ga: 0 };
+    if (m.result1 != null && m.result2 != null) {
+      const t1 = groups[g][m.team1];
+      const t2 = groups[g][m.team2];
+      t1.gf += m.result1;
+      t1.ga += m.result2;
+      t2.gf += m.result2;
+      t2.ga += m.result1;
+      if (m.result1 > m.result2) {
+        t1.points += 3;
+      } else if (m.result1 < m.result2) {
+        t2.points += 3;
+      } else {
+        t1.points += 1;
+        t2.points += 1;
+      }
+    }
+  }
+  return Object.entries(groups).map(([group, teams]) => ({
+    group,
+    teams: Object.values(teams).map(t => ({
+      team: t.team,
+      points: t.points,
+      gf: t.gf,
+      ga: t.ga,
+      gd: t.gf - t.ga
+    })).sort((a, b) =>
+      b.points - a.points || b.gd - a.gd || b.gf - a.gf
+    )
+  }));
+}
+
+router.get('/:competition', async (req, res) => {
+  try {
+    const matches = await Match.find({ competition: req.params.competition });
+    const standings = calculateGroupStandings(matches);
+    res.json(standings);
+  } catch (err) {
+    res.status(500).json({ error: 'Error retrieving group standings' });
+  }
+});
+
+module.exports = { router, calculateGroupStandings };


### PR DESCRIPTION
## Summary
- expose `/groups/:competition` and `/bracket/:competition` APIs
- create `GroupTable` and `EliminationBracket` React components
- update dashboard to display group standings and the knockout bracket

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687461148714832583f2d03a2a090135