### PR TITLE
Add MUI bracket prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,27 @@ Si modificas el frontend de React, genera los archivos estáticos con:
 cd frontend && npm run build
 ```
 
+## Bracket MUI Prototype
+
+El proyecto incluye un componente de prueba que utiliza la librería
+`@g-loot/react-tournament-brackets` con estilos de **MUI**. Para visualizarlo
+en el dashboard necesitas instalar las dependencias adicionales del frontend:
+
+```bash
+cd frontend
+npm install @mui/material @emotion/react @emotion/styled \
+  @g-loot/react-tournament-brackets
+```
+
+Luego inicia el servidor de desarrollo de Vite:
+
+```bash
+npm run dev
+```
+
+Al entrar al panel se mostrará un bloque llamado *Bracket Prototype* con la
+llave de eliminatorias.
+
 En Vercel la compilación del frontend se realiza automáticamente durante el despliegue con `npm run vercel-build` y la carpeta `frontend/dist` queda disponible en producción.
 
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,11 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.4.0"
+    "react-router-dom": "^6.4.0",
+    "@mui/material": "^5.15.0",
+    "@emotion/react": "^11.11.0",
+    "@emotion/styled": "^11.11.0",
+    "@g-loot/react-tournament-brackets": "^1.0.4"
   },
   "devDependencies": {
     "vite": "^4.0.0",

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import GroupTable from './GroupTable';
 import EliminationBracket from './EliminationBracket';
+import MUIBracket from './MUIBracket';
 
 export default function Dashboard() {
   const [user, setUser] = useState(null);
@@ -225,6 +226,7 @@ export default function Dashboard() {
         <div style={{ marginTop: '2rem' }}>
           <h5>Eliminatorias</h5>
           <EliminationBracket bracket={bracket} />
+          <MUIBracket bracket={bracket} />
         </div>
       )}
 

--- a/frontend/src/MUIBracket.jsx
+++ b/frontend/src/MUIBracket.jsx
@@ -1,0 +1,51 @@
+import React, { useMemo } from 'react';
+import { Box, Paper, Typography } from '@mui/material';
+import { SingleEliminationBracket, Match } from '@g-loot/react-tournament-brackets';
+
+export default function MUIBracket({ bracket }) {
+  const matches = useMemo(() => {
+    if (!bracket) return [];
+    const rounds = ['Cuartos de final', 'Semifinales', 'Tercer puesto', 'Final'];
+    let id = 1;
+    const list = [];
+    for (const round of rounds) {
+      const arr = bracket[round] || [];
+      for (const m of arr) {
+        list.push({
+          id: id++,
+          name: round,
+          nextMatchId: null,
+          tournamentRoundText: round,
+          startTime: new Date(`${m.date}T${m.time}`),
+          state: 'SCHEDULED',
+          participants: [
+            { id: m.team1, name: m.team1 },
+            { id: m.team2, name: m.team2 }
+          ]
+        });
+      }
+    }
+    return list;
+  }, [bracket]);
+
+  if (!matches.length) return null;
+
+  const theme = {
+    textColor: '#212121',
+    matchBackground: '#fafafa',
+    score: { background: '#1976d2' }
+  };
+
+  return (
+    <Box sx={{ mt: 3 }}>
+      <Typography variant="h6" gutterBottom>Bracket Prototype</Typography>
+      <Paper sx={{ p: 2, overflowX: 'auto' }}>
+        <SingleEliminationBracket
+          matchComponent={Match}
+          matches={matches}
+          theme={theme}
+        />
+      </Paper>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add instructions for the new bracket prototype with MUI
- include `@g-loot/react-tournament-brackets` and MUI packages in the frontend
- create `MUIBracket` component using the bracket library
- display the component on the dashboard

## Testing
- `npm test` *(fails: jest not found)*
- `npm ci` *(fails: cannot reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_6875561985ec8325bb87c1ba1085b2da