### PR TITLE
Add MUI and refactor React components

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,6 +11,5 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
-    <script src="/js/materialize.min.js"></script>
   </body>
 </html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,10 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.4.0"
+    "react-router-dom": "^6.4.0",
+    "@mui/material": "^5.15.14",
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0"
   },
   "devDependencies": {
     "vite": "^4.0.0",

--- a/frontend/src/Admin.jsx
+++ b/frontend/src/Admin.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Button, Card, CardContent } from '@mui/material';
 
 export default function Admin() {
   const [competitions, setCompetitions] = useState([]);
@@ -232,100 +233,108 @@ export default function Admin() {
     <div className="container" style={{ marginTop: '2rem' }}>
       <h5>Administración</h5>
 
-      <section style={{ marginTop: '2rem' }}>
-        <h6>Competencias</h6>
-        <form onSubmit={createCompetition} style={{ marginBottom: '1rem' }}>
-          <input type="text" value={newCompetition} onChange={e => setNewCompetition(e.target.value)} placeholder="Nombre" required />
-          <input type="file" accept=".json" onChange={e => setCompetitionFile(e.target.files[0])} style={{ marginLeft: '10px' }} />
-          <button className="btn" type="submit" style={{ marginLeft: '10px' }}>Crear</button>
-        </form>
-        <ul className="collection">
-          {competitions.map(c => (
-            <li key={c._id} className="collection-item">
-              <input type="text" value={c.name} onChange={e => updateCompetitionField(c._id, e.target.value)} />
-              <a href="#" className="secondary-content" onClick={e => { e.preventDefault(); saveCompetition(c); }}>💾</a>
-              <a href="#" className="secondary-content red-text" style={{ marginLeft: '1rem' }} onClick={e => { e.preventDefault(); deleteCompetition(c._id); }}>✖</a>
-            </li>
-          ))}
-        </ul>
-      </section>
-
-      <section style={{ marginTop: '2rem' }}>
-        <h6>Owners</h6>
-        <form onSubmit={createOwner} style={{ marginBottom: '1rem' }}>
-          <input type="text" value={ownerForm.username} onChange={e => setOwnerForm({ ...ownerForm, username: e.target.value })} placeholder="Username" required />
-          <input type="password" value={ownerForm.password} onChange={e => setOwnerForm({ ...ownerForm, password: e.target.value })} placeholder="Password" required />
-          <input type="email" value={ownerForm.email} onChange={e => setOwnerForm({ ...ownerForm, email: e.target.value })} placeholder="Email" required />
-          <button className="btn" type="submit" style={{ marginLeft: '10px' }}>Crear</button>
-        </form>
-        <ul className="collection">
-          {owners.map(o => (
-            <li key={o._id} className="collection-item">
-              <input type="text" value={o.username || ''} onChange={e => updateOwnerField(o._id, 'username', e.target.value)} />
-              <input type="email" value={o.email || ''} onChange={e => updateOwnerField(o._id, 'email', e.target.value)} style={{ marginLeft: '10px' }} />
-              <a href="#" className="secondary-content" onClick={e => { e.preventDefault(); saveOwner(o); }}>💾</a>
-              <a href="#" className="secondary-content red-text" style={{ marginLeft: '1rem' }} onClick={e => { e.preventDefault(); deleteOwner(o._id); }}>✖</a>
-            </li>
-          ))}
-        </ul>
-      </section>
-
-      <section style={{ marginTop: '2rem' }}>
-        <h6>Pencas</h6>
-        <form onSubmit={createPenca} style={{ marginBottom: '1rem' }}>
-          <input type="text" value={pencaForm.name} onChange={e => setPencaForm({ ...pencaForm, name: e.target.value })} placeholder="Nombre" required />
-          <select value={pencaForm.owner} onChange={e => setPencaForm({ ...pencaForm, owner: e.target.value })} required>
-            <option value="" disabled>Owner</option>
-            {owners.map(o => (
-              <option key={o._id} value={o._id}>{o.username}</option>
-            ))}
-          </select>
-          <select value={pencaForm.competition} onChange={e => setPencaForm({ ...pencaForm, competition: e.target.value })} required style={{ marginLeft: '10px' }}>
-            <option value="" disabled>Competencia</option>
+      <Card style={{ marginTop: '2rem', padding: '1rem' }}>
+        <CardContent>
+          <h6>Competencias</h6>
+          <form onSubmit={createCompetition} style={{ marginBottom: '1rem' }}>
+            <input type="text" value={newCompetition} onChange={e => setNewCompetition(e.target.value)} placeholder="Nombre" required />
+            <input type="file" accept=".json" onChange={e => setCompetitionFile(e.target.files[0])} style={{ marginLeft: '10px' }} />
+            <Button variant="contained" type="submit" style={{ marginLeft: '10px' }}>Crear</Button>
+          </form>
+          <ul className="collection">
             {competitions.map(c => (
-              <option key={c._id} value={c.name}>{c.name}</option>
+              <li key={c._id} className="collection-item">
+                <input type="text" value={c.name} onChange={e => updateCompetitionField(c._id, e.target.value)} />
+                <a href="#" className="secondary-content" onClick={e => { e.preventDefault(); saveCompetition(c); }}>💾</a>
+                <a href="#" className="secondary-content red-text" style={{ marginLeft: '1rem' }} onClick={e => { e.preventDefault(); deleteCompetition(c._id); }}>✖</a>
+              </li>
             ))}
-          </select>
-          <input type="file" accept=".json" onChange={e => setPencaFile(e.target.files[0])} style={{ marginLeft: '10px' }} />
-          <button className="btn" type="submit" style={{ marginLeft: '10px' }}>Crear</button>
-        </form>
-        <ul className="collection">
-          {pencas.map(p => (
-            <li key={p._id} className="collection-item">
-              <input type="text" value={p.name || ''} onChange={e => updatePencaField(p._id, 'name', e.target.value)} />
-              <select value={p.owner} onChange={e => updatePencaField(p._id, 'owner', e.target.value)} style={{ marginLeft: '10px' }}>
-                {owners.map(o => (
-                  <option key={o._id} value={o._id}>{o.username}</option>
-                ))}
-              </select>
-              <select value={p.competition} onChange={e => updatePencaField(p._id, 'competition', e.target.value)} style={{ marginLeft: '10px' }}>
-                {competitions.map(c => (
-                  <option key={c._id} value={c.name}>{c.name}</option>
-                ))}
-              </select>
-              <a href="#" className="secondary-content" onClick={e => { e.preventDefault(); savePenca(p); }}>💾</a>
-              <a href="#" className="secondary-content red-text" style={{ marginLeft: '1rem' }} onClick={e => { e.preventDefault(); deletePenca(p._id); }}>✖</a>
-            </li>
-      ))}
-      </ul>
-    </section>
+          </ul>
+        </CardContent>
+      </Card>
 
-    <section style={{ marginTop: '2rem' }}>
-      <h6>Matches</h6>
-      <ul className="collection">
-        {matches.map(m => (
-          <li key={m._id} className="collection-item">
-            <input type="text" value={m.team1 || ''} onChange={e => updateMatchField(m._id, 'team1', e.target.value)} />
-            <input type="text" value={m.team2 || ''} onChange={e => updateMatchField(m._id, 'team2', e.target.value)} style={{ marginLeft: '10px' }} />
-            <input type="date" value={m.date || ''} onChange={e => updateMatchField(m._id, 'date', e.target.value)} style={{ marginLeft: '10px' }} />
-            <input type="time" value={m.time || ''} onChange={e => updateMatchField(m._id, 'time', e.target.value)} style={{ marginLeft: '10px' }} />
-            <input type="number" value={m.result1 ?? ''} onChange={e => updateMatchField(m._id, 'result1', e.target.value)} style={{ marginLeft: '10px', width: '60px' }} />
-            <input type="number" value={m.result2 ?? ''} onChange={e => updateMatchField(m._id, 'result2', e.target.value)} style={{ marginLeft: '10px', width: '60px' }} />
-            <a href="#" className="secondary-content" onClick={e => { e.preventDefault(); saveMatch(m); }}>💾</a>
-          </li>
-        ))}
-      </ul>
-    </section>
+      <Card style={{ marginTop: '2rem', padding: '1rem' }}>
+        <CardContent>
+          <h6>Owners</h6>
+          <form onSubmit={createOwner} style={{ marginBottom: '1rem' }}>
+            <input type="text" value={ownerForm.username} onChange={e => setOwnerForm({ ...ownerForm, username: e.target.value })} placeholder="Username" required />
+            <input type="password" value={ownerForm.password} onChange={e => setOwnerForm({ ...ownerForm, password: e.target.value })} placeholder="Password" required />
+            <input type="email" value={ownerForm.email} onChange={e => setOwnerForm({ ...ownerForm, email: e.target.value })} placeholder="Email" required />
+            <Button variant="contained" type="submit" style={{ marginLeft: '10px' }}>Crear</Button>
+          </form>
+          <ul className="collection">
+            {owners.map(o => (
+              <li key={o._id} className="collection-item">
+                <input type="text" value={o.username || ''} onChange={e => updateOwnerField(o._id, 'username', e.target.value)} />
+                <input type="email" value={o.email || ''} onChange={e => updateOwnerField(o._id, 'email', e.target.value)} style={{ marginLeft: '10px' }} />
+                <a href="#" className="secondary-content" onClick={e => { e.preventDefault(); saveOwner(o); }}>💾</a>
+                <a href="#" className="secondary-content red-text" style={{ marginLeft: '1rem' }} onClick={e => { e.preventDefault(); deleteOwner(o._id); }}>✖</a>
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+
+      <Card style={{ marginTop: '2rem', padding: '1rem' }}>
+        <CardContent>
+          <h6>Pencas</h6>
+          <form onSubmit={createPenca} style={{ marginBottom: '1rem' }}>
+            <input type="text" value={pencaForm.name} onChange={e => setPencaForm({ ...pencaForm, name: e.target.value })} placeholder="Nombre" required />
+            <select value={pencaForm.owner} onChange={e => setPencaForm({ ...pencaForm, owner: e.target.value })} required>
+              <option value="" disabled>Owner</option>
+              {owners.map(o => (
+                <option key={o._id} value={o._id}>{o.username}</option>
+              ))}
+            </select>
+            <select value={pencaForm.competition} onChange={e => setPencaForm({ ...pencaForm, competition: e.target.value })} required style={{ marginLeft: '10px' }}>
+              <option value="" disabled>Competencia</option>
+              {competitions.map(c => (
+                <option key={c._id} value={c.name}>{c.name}</option>
+              ))}
+            </select>
+            <input type="file" accept=".json" onChange={e => setPencaFile(e.target.files[0])} style={{ marginLeft: '10px' }} />
+            <Button variant="contained" type="submit" style={{ marginLeft: '10px' }}>Crear</Button>
+          </form>
+          <ul className="collection">
+            {pencas.map(p => (
+              <li key={p._id} className="collection-item">
+                <input type="text" value={p.name || ''} onChange={e => updatePencaField(p._id, 'name', e.target.value)} />
+                <select value={p.owner} onChange={e => updatePencaField(p._id, 'owner', e.target.value)} style={{ marginLeft: '10px' }}>
+                  {owners.map(o => (
+                    <option key={o._id} value={o._id}>{o.username}</option>
+                  ))}
+                </select>
+                <select value={p.competition} onChange={e => updatePencaField(p._id, 'competition', e.target.value)} style={{ marginLeft: '10px' }}>
+                  {competitions.map(c => (
+                    <option key={c._id} value={c.name}>{c.name}</option>
+                  ))}
+                </select>
+                <a href="#" className="secondary-content" onClick={e => { e.preventDefault(); savePenca(p); }}>💾</a>
+                <a href="#" className="secondary-content red-text" style={{ marginLeft: '1rem' }} onClick={e => { e.preventDefault(); deletePenca(p._id); }}>✖</a>
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+
+      <Card style={{ marginTop: '2rem', padding: '1rem' }}>
+        <CardContent>
+          <h6>Matches</h6>
+          <ul className="collection">
+            {matches.map(m => (
+              <li key={m._id} className="collection-item">
+                <input type="text" value={m.team1 || ''} onChange={e => updateMatchField(m._id, 'team1', e.target.value)} />
+                <input type="text" value={m.team2 || ''} onChange={e => updateMatchField(m._id, 'team2', e.target.value)} style={{ marginLeft: '10px' }} />
+                <input type="date" value={m.date || ''} onChange={e => updateMatchField(m._id, 'date', e.target.value)} style={{ marginLeft: '10px' }} />
+                <input type="time" value={m.time || ''} onChange={e => updateMatchField(m._id, 'time', e.target.value)} style={{ marginLeft: '10px' }} />
+                <input type="number" value={m.result1 ?? ''} onChange={e => updateMatchField(m._id, 'result1', e.target.value)} style={{ marginLeft: '10px', width: '60px' }} />
+                <input type="number" value={m.result2 ?? ''} onChange={e => updateMatchField(m._id, 'result2', e.target.value)} style={{ marginLeft: '10px', width: '60px' }} />
+                <a href="#" className="secondary-content" onClick={e => { e.preventDefault(); saveMatch(m); }}>💾</a>
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
   </div>
   );
 }

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import GroupTable from './GroupTable';
 import EliminationBracket from './EliminationBracket';
+import { Button, Card, CardContent } from '@mui/material';
 
 export default function Dashboard() {
   const [user, setUser] = useState(null);
@@ -162,40 +163,45 @@ export default function Dashboard() {
         const ranking = rankings[p._id] || [];
         return (
           <div key={p._id} style={{ marginBottom: '1rem' }}>
-            <div
-              style={{ padding: '1rem', border: '1px solid #ccc', borderRadius: '4px', cursor: 'pointer' }}
+            <Card
+              style={{ padding: '1rem', cursor: 'pointer' }}
               onClick={() => setOpen(open === p._id ? null : p._id)}
             >
-              <strong>{p.name}</strong>
-            </div>
+              <CardContent>
+                <strong>{p.name}</strong>
+              </CardContent>
+            </Card>
             {open === p._id && (
-              <div style={{ border: '1px solid #ccc', borderTop: 'none', padding: '1rem' }}>
+              <Card style={{ marginTop: '0', borderTop: 'none', padding: '1rem' }}>
+                <CardContent>
                 {pMatches.map(m => {
                   const pr = getPrediction(p._id, m._id) || {};
                   return (
-                    <div key={m._id} className={pr.result1 !== undefined ? 'match-card saved' : 'match-card'}>
-                      <div className="match-header">
-                        <div className="team">
-                          <img src={`/images/${m.team1.replace(/\s+/g, '').toLowerCase()}.png`} alt={m.team1} className="circle responsive-img" />
-                          <span className="team-name">{m.team1}</span>
-                        </div>
-                        <span className="vs">vs</span>
-                        <div className="team">
-                          <img src={`/images/${m.team2.replace(/\s+/g, '').toLowerCase()}.png`} alt={m.team2} className="circle responsive-img" />
-                          <span className="team-name">{m.team2}</span>
-                        </div>
-                      </div>
-                      <div className="match-details">
-                        <form onSubmit={e => handlePrediction(e, p._id, m._id)}>
-                          <div className="input-field inline">
-                            <input name="result1" type="number" defaultValue={pr.result1 || ''} required />
-                            <span>-</span>
-                            <input name="result2" type="number" defaultValue={pr.result2 || ''} required />
+                    <Card key={m._id} className={pr.result1 !== undefined ? 'match-card saved' : 'match-card'}>
+                      <CardContent>
+                        <div className="match-header">
+                          <div className="team">
+                            <img src={`/images/${m.team1.replace(/\s+/g, '').toLowerCase()}.png`} alt={m.team1} className="circle responsive-img" />
+                            <span className="team-name">{m.team1}</span>
                           </div>
-                          <button className="btn" type="submit">Guardar</button>
-                        </form>
-                      </div>
-                    </div>
+                          <span className="vs">vs</span>
+                          <div className="team">
+                            <img src={`/images/${m.team2.replace(/\s+/g, '').toLowerCase()}.png`} alt={m.team2} className="circle responsive-img" />
+                            <span className="team-name">{m.team2}</span>
+                          </div>
+                        </div>
+                        <div className="match-details">
+                          <form onSubmit={e => handlePrediction(e, p._id, m._id)}>
+                            <div className="input-field inline">
+                              <input name="result1" type="number" defaultValue={pr.result1 || ''} required />
+                              <span>-</span>
+                              <input name="result2" type="number" defaultValue={pr.result2 || ''} required />
+                            </div>
+                            <Button variant="contained" type="submit">Guardar</Button>
+                          </form>
+                        </div>
+                      </CardContent>
+                    </Card>
                   );
                 })}
                 <div style={{ marginTop: '1rem' }}>
@@ -208,7 +214,8 @@ export default function Dashboard() {
                     ))}
                   </ul>
                 </div>
-              </div>
+                </CardContent>
+              </Card>
             )}
           </div>
         );
@@ -232,7 +239,7 @@ export default function Dashboard() {
         <div style={{ marginTop: '2rem' }}>
           <h6>Unirse a una Penca</h6>
           <input type="text" value={joinCode} onChange={e => setJoinCode(e.target.value)} placeholder="Código" />
-          <button className="btn" onClick={handleJoin} style={{ marginLeft: '10px' }}>Solicitar</button>
+          <Button variant="contained" onClick={handleJoin} style={{ marginLeft: '10px' }}>Solicitar</Button>
           {joinMsg && <div style={{ marginTop: '0.5rem' }}>{joinMsg}</div>}
         </div>
       )}

--- a/frontend/src/EliminationBracket.jsx
+++ b/frontend/src/EliminationBracket.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Card, CardContent, Typography } from '@mui/material';
 
 export default function EliminationBracket({ bracket }) {
   if (!bracket) return null;
@@ -10,22 +11,30 @@ export default function EliminationBracket({ bracket }) {
           <div key={r} style={{ marginBottom: '1rem' }}>
             <h6>{r}</h6>
             {bracket[r].map(m => (
-              <div key={m._id} className="match-card">
-                <div className="match-header">
-                  <div className="team">
-                    <span className="team-name">{m.team1}</span>
+              <Card key={m._id} className="match-card">
+                <CardContent>
+                  <div className="match-header">
+                    <div className="team">
+                      <Typography variant="body1" className="team-name">
+                        {m.team1}
+                      </Typography>
+                    </div>
+                    <Typography variant="body2" className="vs">
+                      vs
+                    </Typography>
+                    <div className="team">
+                      <Typography variant="body1" className="team-name">
+                        {m.team2}
+                      </Typography>
+                    </div>
                   </div>
-                  <span className="vs">vs</span>
-                  <div className="team">
-                    <span className="team-name">{m.team2}</span>
-                  </div>
-                </div>
-                {m.result1 != null && m.result2 != null && (
-                  <div className="match-details">
-                    {m.result1} - {m.result2}
-                  </div>
-                )}
-              </div>
+                  {m.result1 != null && m.result2 != null && (
+                    <div className="match-details">
+                      {m.result1} - {m.result2}
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
             ))}
           </div>
         ) : null

--- a/frontend/src/GroupTable.jsx
+++ b/frontend/src/GroupTable.jsx
@@ -1,4 +1,13 @@
 import React from 'react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper
+} from '@mui/material';
 
 export default function GroupTable({ groups }) {
   if (!groups || !groups.length) return null;
@@ -7,28 +16,30 @@ export default function GroupTable({ groups }) {
       {groups.map(g => (
         <div key={g.group} style={{ marginBottom: '1rem' }}>
           <h6>{g.group}</h6>
-          <table className="striped">
-            <thead>
-              <tr>
-                <th>Equipo</th>
-                <th>Pts</th>
-                <th>DG</th>
-                <th>GF</th>
-              </tr>
-            </thead>
-            <tbody>
-              {g.teams
-                .sort((a, b) => b.points - a.points || b.gd - a.gd || b.gf - a.gf)
-                .map(t => (
-                  <tr key={t.team}>
-                    <td>{t.team}</td>
-                    <td>{t.points}</td>
-                    <td>{t.gd}</td>
-                    <td>{t.gf}</td>
-                  </tr>
-                ))}
-            </tbody>
-          </table>
+          <TableContainer component={Paper}>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Equipo</TableCell>
+                  <TableCell>Pts</TableCell>
+                  <TableCell>DG</TableCell>
+                  <TableCell>GF</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {g.teams
+                  .sort((a, b) => b.points - a.points || b.gd - a.gd || b.gf - a.gf)
+                  .map(t => (
+                    <TableRow key={t.team}>
+                      <TableCell>{t.team}</TableCell>
+                      <TableCell>{t.points}</TableCell>
+                      <TableCell>{t.gd}</TableCell>
+                      <TableCell>{t.gf}</TableCell>
+                    </TableRow>
+                  ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
         </div>
       ))}
     </div>

--- a/frontend/src/Login.jsx
+++ b/frontend/src/Login.jsx
@@ -1,5 +1,12 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import {
+  Button,
+  Card,
+  CardContent,
+  TextField,
+  Typography
+} from '@mui/material';
 
 export default function Login() {
   const [username, setUsername] = useState('');
@@ -32,22 +39,43 @@ export default function Login() {
   };
 
   return (
-    <div className="login-container card">
-      <h5>Iniciar Sesión</h5>
-      <form onSubmit={handleSubmit}>
-        <div className="input-field">
-          <input id="login-username" type="text" value={username} onChange={(e) => setUsername(e.target.value)} required />
-          <label htmlFor="login-username" className="active">Nombre de usuario</label>
-        </div>
-        <div className="input-field">
-          <input id="login-password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
-          <label htmlFor="login-password" className="active">Contraseña</label>
-        </div>
-        <button className="btn" type="submit">Ingresar</button>
-      </form>
-      {error && (
-        <div className="red-text" style={{ marginTop: '1rem' }}>{error}</div>
-      )}
-    </div>
+    <Card className="login-container">
+      <CardContent>
+        <Typography variant="h5" gutterBottom>
+          Iniciar Sesión
+        </Typography>
+        <form onSubmit={handleSubmit}>
+          <div className="input-field">
+            <TextField
+              id="login-username"
+              label="Nombre de usuario"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              required
+              fullWidth
+              margin="normal"
+            />
+          </div>
+          <div className="input-field">
+            <TextField
+              id="login-password"
+              label="Contraseña"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              fullWidth
+              margin="normal"
+            />
+          </div>
+          <Button variant="contained" type="submit" fullWidth>
+            Ingresar
+          </Button>
+        </form>
+        {error && (
+          <div className="red-text" style={{ marginTop: '1rem' }}>{error}</div>
+        )}
+      </CardContent>
+    </Card>
   );
 }


### PR DESCRIPTION
## Summary
- integrate @mui/material and emotion packages
- remove old Materialize script
- refactor Login, Dashboard, Admin and other components to use MUI
- update tables with MUI Table components

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875561a5f10832591cb40e6fca7ccc9