### PR TITLE
Add FIFA 2026 bracket logic

### DIFF
--- a/tests/bracket.test.js
+++ b/tests/bracket.test.js
@@ -1,5 +1,5 @@
 const Match = require('../models/Match');
-const { calculateGroupStandings } = require('../utils/bracket');
+const { calculateGroupStandings, rankThirdPlacedTeams } = require('../utils/bracket');
 
 
 jest.mock('../models/Match', () => ({
@@ -27,5 +27,28 @@ describe('Bracket helpers', () => {
     expect(standings['Grupo A'].map(t => t.team)).toEqual(['A1', 'A2', 'A3']);
     expect(standings['Grupo B'].map(t => t.team)).toEqual(['B2', 'B3', 'B1']);
 
+  });
+
+  it('ranks third placed teams', () => {
+    const standings = {
+      'Grupo A': [
+        { team: 'A1', points: 6, gd: 4, gf: 5 },
+        { team: 'A2', points: 3, gd: 0, gf: 3 },
+        { team: 'A3', points: 1, gd: -2, gf: 1 }
+      ],
+      'Grupo B': [
+        { team: 'B1', points: 4, gd: 1, gf: 4 },
+        { team: 'B2', points: 4, gd: 0, gf: 2 },
+        { team: 'B3', points: 0, gd: -3, gf: 1 }
+      ],
+      'Grupo C': [
+        { team: 'C1', points: 5, gd: 2, gf: 4 },
+        { team: 'C2', points: 4, gd: 1, gf: 3 },
+        { team: 'C3', points: 2, gd: -1, gf: 2 }
+      ]
+    };
+
+    const ranked = rankThirdPlacedTeams(standings);
+    expect(ranked.map(t => t.team)).toEqual(['C3', 'A3', 'B3']);
   });
 });


### PR DESCRIPTION
## Summary
- support generating knockout matches for tournaments with 12 groups
- expose helper to rank third‑placed teams
- test third‑place ranking logic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687560004acc8325b23d30d1834d20cb