### PR TITLE
Implement round order helper for match sorting

### DIFF
--- a/frontend/src/Admin.jsx
+++ b/frontend/src/Admin.jsx
@@ -8,6 +8,7 @@ import {
   AccordionDetails,
   Typography
 } from '@mui/material';
+import roundOrder from './roundOrder';
 
 
 export default function Admin() {
@@ -342,7 +343,16 @@ export default function Admin() {
       <Card style={{ marginTop: '2rem', padding: '1rem' }}>
         <CardContent>
           <h6>Matches</h6>
-          {Object.keys(groupedMatches).sort().map(g => (
+          {Object.keys(groupedMatches)
+            .sort((a, b) => {
+              const ai = roundOrder.indexOf(a);
+              const bi = roundOrder.indexOf(b);
+              if (ai === -1 && bi === -1) return a.localeCompare(b);
+              if (ai === -1) return 1;
+              if (bi === -1) return -1;
+              return ai - bi;
+            })
+            .map(g => (
             <Accordion key={g} sx={{ marginTop: '1rem' }}>
               <AccordionSummary expandIcon="\u25BC">
                 <Typography variant="subtitle1">{g}</Typography>

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -3,6 +3,7 @@ import GroupTable from './GroupTable';
 import EliminationBracket from './EliminationBracket';
 import { Button, Card, CardContent } from '@mui/material';
 import MUIBracket from './MUIBracket';
+import roundOrder from './roundOrder';
 
 
 export default function Dashboard() {
@@ -191,7 +192,14 @@ export default function Dashboard() {
                 <CardContent>
                 {Object.keys(pMatches)
                   .filter(g => g.startsWith('Grupo'))
-                  .sort()
+                  .sort((a, b) => {
+                    const ai = roundOrder.indexOf(a);
+                    const bi = roundOrder.indexOf(b);
+                    if (ai === -1 && bi === -1) return a.localeCompare(b);
+                    if (ai === -1) return 1;
+                    if (bi === -1) return -1;
+                    return ai - bi;
+                  })
                   .map(g => (
                     <div key={g} style={{ marginBottom: '1rem' }}>
                       <h6>{g}</h6>
@@ -231,7 +239,8 @@ export default function Dashboard() {
                 {!bracket && (
                   <div style={{ marginTop: '1rem' }}>
                     <h6>Eliminatorias</h6>
-                    {['Cuartos de final', 'Semifinales', 'Tercer puesto', 'Final']
+                    {roundOrder
+                      .slice(4)
                       .filter(r => pMatches[r])
                       .map(r => (
                         <div key={r} style={{ marginBottom: '1rem' }}>

--- a/frontend/src/EliminationBracket.jsx
+++ b/frontend/src/EliminationBracket.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { Card, CardContent, Typography } from '@mui/material';
+import roundOrder from './roundOrder';
 
 export default function EliminationBracket({ bracket }) {
   if (!bracket) return null;
-  const order = ['Cuartos de final', 'Semifinales', 'Tercer puesto', 'Final'];
+  const order = roundOrder.slice(4);
   return (
     <div>
       {order.map(r => (

--- a/frontend/src/MUIBracket.jsx
+++ b/frontend/src/MUIBracket.jsx
@@ -1,11 +1,12 @@
 import React, { useMemo } from 'react';
 import { Box, Paper, Typography } from '@mui/material';
 import { SingleEliminationBracket, Match } from '@g-loot/react-tournament-brackets';
+import roundOrder from './roundOrder';
 
 export default function MUIBracket({ bracket }) {
   const matches = useMemo(() => {
     if (!bracket) return [];
-    const rounds = ['Cuartos de final', 'Semifinales', 'Tercer puesto', 'Final'];
+    const rounds = roundOrder.slice(4);
     let id = 1;
     const list = [];
     for (const round of rounds) {

--- a/frontend/src/roundOrder.js
+++ b/frontend/src/roundOrder.js
@@ -1,0 +1,12 @@
+const roundOrder = [
+  'Grupo A',
+  'Grupo B',
+  'Grupo C',
+  'Grupo D',
+  'Cuartos de final',
+  'Semifinales',
+  'Tercer puesto',
+  'Final'
+];
+
+export default roundOrder;


### PR DESCRIPTION
## Summary
- add `roundOrder` helper listing stages in display order
- sort match groups in `Admin` and `Dashboard` using `roundOrder`
- reuse `roundOrder` in bracket components

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6876562f00c08325ad586605f11b7def