### PR TITLE
Group matches by competition and round

### DIFF
--- a/frontend/src/Admin.jsx
+++ b/frontend/src/Admin.jsx
@@ -238,10 +238,12 @@ export default function Admin() {
     }
   }
 
-  const groupedMatches = matches.reduce((acc, m) => {
-    const g = m.group_name || 'Otros';
-    if (!acc[g]) acc[g] = [];
-    acc[g].push(m);
+  const matchesByCompetition = matches.reduce((acc, m) => {
+    const comp = m.competition || 'Otros';
+    const round = m.group_name || 'Otros';
+    if (!acc[comp]) acc[comp] = {};
+    if (!acc[comp][round]) acc[comp][round] = [];
+    acc[comp][round].push(m);
     return acc;
   }, {});
 
@@ -342,25 +344,34 @@ export default function Admin() {
       <Card style={{ marginTop: '2rem', padding: '1rem' }}>
         <CardContent>
           <h6>Matches</h6>
-          {Object.keys(groupedMatches).sort().map(g => (
-            <Accordion key={g} sx={{ marginTop: '1rem' }}>
+          {Object.keys(matchesByCompetition).sort().map(comp => (
+            <Accordion key={comp} sx={{ marginTop: '1rem' }}>
               <AccordionSummary expandIcon="\u25BC">
-                <Typography variant="subtitle1">{g}</Typography>
+                <Typography variant="subtitle1">{comp}</Typography>
               </AccordionSummary>
               <AccordionDetails>
-                <ul className="collection">
-                  {groupedMatches[g].map(m => (
-                    <li key={m._id} className="collection-item">
-                      <input type="text" value={m.team1 || ''} onChange={e => updateMatchField(m._id, 'team1', e.target.value)} />
-                      <input type="text" value={m.team2 || ''} onChange={e => updateMatchField(m._id, 'team2', e.target.value)} style={{ marginLeft: '10px' }} />
-                      <input type="date" value={m.date || ''} onChange={e => updateMatchField(m._id, 'date', e.target.value)} style={{ marginLeft: '10px' }} />
-                      <input type="time" value={m.time || ''} onChange={e => updateMatchField(m._id, 'time', e.target.value)} style={{ marginLeft: '10px' }} />
-                      <input type="number" value={m.result1 ?? ''} onChange={e => updateMatchField(m._id, 'result1', e.target.value)} style={{ marginLeft: '10px', width: '60px' }} />
-                      <input type="number" value={m.result2 ?? ''} onChange={e => updateMatchField(m._id, 'result2', e.target.value)} style={{ marginLeft: '10px', width: '60px' }} />
-                      <a href="#" className="secondary-content" onClick={e => { e.preventDefault(); saveMatch(m); }}>💾</a>
-                    </li>
-                  ))}
-                </ul>
+                {Object.keys(matchesByCompetition[comp]).sort().map(r => (
+                  <Accordion key={r} sx={{ marginTop: '0.5rem', marginLeft: '1rem' }}>
+                    <AccordionSummary expandIcon="\u25BC">
+                      <Typography variant="subtitle2">{r}</Typography>
+                    </AccordionSummary>
+                    <AccordionDetails>
+                      <ul className="collection">
+                        {matchesByCompetition[comp][r].map(m => (
+                          <li key={m._id} className="collection-item">
+                            <input type="text" value={m.team1 || ''} onChange={e => updateMatchField(m._id, 'team1', e.target.value)} />
+                            <input type="text" value={m.team2 || ''} onChange={e => updateMatchField(m._id, 'team2', e.target.value)} style={{ marginLeft: '10px' }} />
+                            <input type="date" value={m.date || ''} onChange={e => updateMatchField(m._id, 'date', e.target.value)} style={{ marginLeft: '10px' }} />
+                            <input type="time" value={m.time || ''} onChange={e => updateMatchField(m._id, 'time', e.target.value)} style={{ marginLeft: '10px' }} />
+                            <input type="number" value={m.result1 ?? ''} onChange={e => updateMatchField(m._id, 'result1', e.target.value)} style={{ marginLeft: '10px', width: '60px' }} />
+                            <input type="number" value={m.result2 ?? ''} onChange={e => updateMatchField(m._id, 'result2', e.target.value)} style={{ marginLeft: '10px', width: '60px' }} />
+                            <a href="#" className="secondary-content" onClick={e => { e.preventDefault(); saveMatch(m); }}>💾</a>
+                          </li>
+                        ))}
+                      </ul>
+                    </AccordionDetails>
+                  </Accordion>
+                ))}
               </AccordionDetails>
             </Accordion>
           ))}


### PR DESCRIPTION
## Summary
- reorganize match grouping logic in Admin page
- render matches by competition, then by round so it's easier to manage

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876562f7c908325905e17188d677887