### PR TITLE
Add Node.js CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 18
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: ./scripts/setup-tests.sh
+      - name: Run tests
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ npm ci
 cd frontend && npm ci
 ```
 
-En entornos de integración continua puedes ejecutar el script `scripts/setup-tests.sh` o utilizar `npm ci` para garantizar instalaciones reproducibles.
+En entornos de integración continua puedes ejecutar el script `scripts/setup-tests.sh` o utilizar `npm ci` para garantizar instalaciones reproducibles. Este repositorio incluye
+un workflow de GitHub Actions (`.github/workflows/ci.yml`) que instala las dependencias con `npm ci` antes de ejecutar `npm test`.
 
 Para lanzar todas las pruebas:
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to install deps with `npm ci` before running tests
- document the workflow in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876563369c08325a3ef3c5168e3b554