### PR TITLE
Fix frontend dependency install

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,15 +130,18 @@ como opción de respaldo para recalcular manualmente si fuera necesario.
 
 
 Antes de ejecutar las pruebas asegúrate de instalar todas las dependencias de
-desarrollo. Para obtener una instalación reproducible puedes utilizar `npm ci`
-tanto en la raíz del proyecto como dentro de `frontend/`:
+desarrollo. Para obtener una instalación reproducible ejecuta `npm ci` en la raíz
+del proyecto. El frontend no incluye `package-lock.json`, por lo que allí debes
+usar `npm install`:
 
 ```bash
 npm ci
-cd frontend && npm ci
+cd frontend && npm install
 ```
 
-En entornos de integración continua puedes ejecutar el script `scripts/setup-tests.sh` o utilizar `npm ci` para garantizar instalaciones reproducibles.
+En entornos de integración continua puedes ejecutar el script `scripts/setup-tests.sh`,
+que utilizará `npm ci` o `npm install` según corresponda para garantizar instalaciones
+reproducibles.
 
 Para lanzar todas las pruebas:
 

--- a/scripts/setup-tests.sh
+++ b/scripts/setup-tests.sh
@@ -10,5 +10,10 @@ fi
 
 # Install frontend dev dependencies if the frontend folder exists and they aren't installed
 if [ -d frontend ]; then
-  (cd frontend && [ ! -d node_modules ] && npm ci)
+  (cd frontend && [ ! -d node_modules ] && \
+    if [ -f package-lock.json ]; then
+      npm ci
+    else
+      npm install
+    fi)
 fi


### PR DESCRIPTION
## Summary
- fallback to `npm install` in setup script if the frontend lacks a lock file
- update instructions to use `npm install` inside `frontend`

## Testing
- `./scripts/setup-tests.sh` *(fails: 403 Forbidden - registry.npmjs.org)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687660b7e97483258b2c8e3355aefa3e