### PR TITLE
Extend competitions with group config

### DIFF
--- a/frontend/src/Admin.jsx
+++ b/frontend/src/Admin.jsx
@@ -19,7 +19,7 @@ export default function Admin() {
   const [matches, setMatches] = useState([]);
   const [groups, setGroups] = useState({});
 
-  const [newCompetition, setNewCompetition] = useState('');
+  const [newCompetition, setNewCompetition] = useState({ name: '', groupsCount: '', integrantsPerGroup: '' });
   const [competitionFile, setCompetitionFile] = useState(null);
   const [ownerForm, setOwnerForm] = useState({ username: '', password: '', email: '' });
   const [pencaForm, setPencaForm] = useState({ name: '', owner: '', competition: '' });
@@ -92,14 +92,16 @@ export default function Admin() {
     e.preventDefault();
     try {
       const data = new FormData();
-      data.append('name', newCompetition);
+      data.append('name', newCompetition.name);
+      if (newCompetition.groupsCount) data.append('groupsCount', newCompetition.groupsCount);
+      if (newCompetition.integrantsPerGroup) data.append('integrantsPerGroup', newCompetition.integrantsPerGroup);
       if (competitionFile) data.append('fixture', competitionFile);
       const res = await fetch('/admin/competitions', {
         method: 'POST',
         body: data
       });
       if (res.ok) {
-        setNewCompetition('');
+        setNewCompetition({ name: '', groupsCount: '', integrantsPerGroup: '' });
         setCompetitionFile(null);
         loadCompetitions();
       }
@@ -108,8 +110,8 @@ export default function Admin() {
     }
   }
 
-  const updateCompetitionField = (id, value) => {
-    setCompetitions(cs => cs.map(c => c._id === id ? { ...c, name: value } : c));
+  const updateCompetitionField = (id, field, value) => {
+    setCompetitions(cs => cs.map(c => c._id === id ? { ...c, [field]: value } : c));
   };
 
   async function saveCompetition(comp) {
@@ -117,7 +119,11 @@ export default function Admin() {
       const res = await fetch(`/admin/competitions/${comp._id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: comp.name })
+        body: JSON.stringify({
+          name: comp.name,
+          groupsCount: comp.groupsCount === '' ? null : Number(comp.groupsCount),
+          integrantsPerGroup: comp.integrantsPerGroup === '' ? null : Number(comp.integrantsPerGroup)
+        })
       });
       if (res.ok) loadCompetitions();
     } catch (err) {
@@ -280,7 +286,9 @@ export default function Admin() {
         </AccordionSummary>
         <AccordionDetails>
           <form onSubmit={createCompetition} style={{ marginBottom: '1rem' }}>
-            <input type="text" value={newCompetition} onChange={e => setNewCompetition(e.target.value)} placeholder="Nombre" required />
+            <input type="text" value={newCompetition.name} onChange={e => setNewCompetition({ ...newCompetition, name: e.target.value })} placeholder="Nombre" required />
+            <input type="number" value={newCompetition.groupsCount} onChange={e => setNewCompetition({ ...newCompetition, groupsCount: e.target.value })} placeholder="Grupos" style={{ marginLeft: '10px', width: '80px' }} />
+            <input type="number" value={newCompetition.integrantsPerGroup} onChange={e => setNewCompetition({ ...newCompetition, integrantsPerGroup: e.target.value })} placeholder="Integrantes" style={{ marginLeft: '10px', width: '100px' }} />
             <input type="file" accept=".json" onChange={e => setCompetitionFile(e.target.files[0])} style={{ marginLeft: '10px' }} />
             <Button variant="contained" type="submit" style={{ marginLeft: '10px' }}>Crear</Button>
           </form>
@@ -290,7 +298,9 @@ export default function Admin() {
                 <Typography>{c.name}</Typography>
               </AccordionSummary>
               <AccordionDetails>
-                <input type="text" value={c.name} onChange={e => updateCompetitionField(c._id, e.target.value)} />
+                <input type="text" value={c.name} onChange={e => updateCompetitionField(c._id, 'name', e.target.value)} />
+                <input type="number" value={c.groupsCount ?? ''} onChange={e => updateCompetitionField(c._id, 'groupsCount', e.target.value)} style={{ marginLeft: '10px', width: '80px' }} />
+                <input type="number" value={c.integrantsPerGroup ?? ''} onChange={e => updateCompetitionField(c._id, 'integrantsPerGroup', e.target.value)} style={{ marginLeft: '10px', width: '100px' }} />
                 <a href="#" className="secondary-content" onClick={e => { e.preventDefault(); saveCompetition(c); }}>💾</a>
                 <a href="#" className="secondary-content red-text" style={{ marginLeft: '1rem' }} onClick={e => { e.preventDefault(); deleteCompetition(c._id); }}>✖</a>
               </AccordionDetails>

--- a/models/Competition.js
+++ b/models/Competition.js
@@ -1,7 +1,9 @@
 const mongoose = require('mongoose');
 
 const competitionSchema = new mongoose.Schema({
-    name: { type: String, unique: true, required: true }
+    name: { type: String, unique: true, required: true },
+    groupsCount: Number,
+    integrantsPerGroup: Number
 });
 
 module.exports = mongoose.models.Competition || mongoose.model('Competition', competitionSchema);


### PR DESCRIPTION
## Summary
- add `groupsCount` and `integrantsPerGroup` fields to Competition model
- allow creating competitions with group info and generating placeholder fixtures
- expose these fields through admin routes
- update Admin page to input and modify group settings

## Testing
- `npm test` *(fails: `jest` not found due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_687688847350832598f1e153849829ed