### PR TITLE
Add competition creation wizard

### DIFF
--- a/frontend/src/Admin.jsx
+++ b/frontend/src/Admin.jsx
@@ -10,6 +10,7 @@ import {
 } from '@mui/material';
 import GroupTable from './GroupTable';
 import roundOrder from './roundOrder';
+import CompetitionWizard from './CompetitionWizard';
 
 
 export default function Admin() {
@@ -19,8 +20,7 @@ export default function Admin() {
   const [matches, setMatches] = useState([]);
   const [groups, setGroups] = useState({});
 
-  const [newCompetition, setNewCompetition] = useState({ name: '', groupsCount: '', integrantsPerGroup: '' });
-  const [competitionFile, setCompetitionFile] = useState(null);
+  const [wizardOpen, setWizardOpen] = useState(false);
   const [ownerForm, setOwnerForm] = useState({ username: '', password: '', email: '' });
   const [pencaForm, setPencaForm] = useState({ name: '', owner: '', competition: '' });
 
@@ -88,27 +88,6 @@ export default function Admin() {
     setGroups(result);
   }
 
-  async function createCompetition(e) {
-    e.preventDefault();
-    try {
-      const data = new FormData();
-      data.append('name', newCompetition.name);
-      if (newCompetition.groupsCount) data.append('groupsCount', newCompetition.groupsCount);
-      if (newCompetition.integrantsPerGroup) data.append('integrantsPerGroup', newCompetition.integrantsPerGroup);
-      if (competitionFile) data.append('fixture', competitionFile);
-      const res = await fetch('/admin/competitions', {
-        method: 'POST',
-        body: data
-      });
-      if (res.ok) {
-        setNewCompetition({ name: '', groupsCount: '', integrantsPerGroup: '' });
-        setCompetitionFile(null);
-        loadCompetitions();
-      }
-    } catch (err) {
-      console.error('create competition error', err);
-    }
-  }
 
   const updateCompetitionField = (id, field, value) => {
     setCompetitions(cs => cs.map(c => c._id === id ? { ...c, [field]: value } : c));
@@ -285,13 +264,7 @@ export default function Admin() {
           <Typography variant="subtitle1">Competencias</Typography>
         </AccordionSummary>
         <AccordionDetails>
-          <form onSubmit={createCompetition} style={{ marginBottom: '1rem' }}>
-            <input type="text" value={newCompetition.name} onChange={e => setNewCompetition({ ...newCompetition, name: e.target.value })} placeholder="Nombre" required />
-            <input type="number" value={newCompetition.groupsCount} onChange={e => setNewCompetition({ ...newCompetition, groupsCount: e.target.value })} placeholder="Grupos" style={{ marginLeft: '10px', width: '80px' }} />
-            <input type="number" value={newCompetition.integrantsPerGroup} onChange={e => setNewCompetition({ ...newCompetition, integrantsPerGroup: e.target.value })} placeholder="Integrantes" style={{ marginLeft: '10px', width: '100px' }} />
-            <input type="file" accept=".json" onChange={e => setCompetitionFile(e.target.files[0])} style={{ marginLeft: '10px' }} />
-            <Button variant="contained" type="submit" style={{ marginLeft: '10px' }}>Crear</Button>
-          </form>
+          <Button variant="contained" onClick={() => setWizardOpen(true)} style={{ marginBottom: '1rem' }}>Nueva competencia</Button>
           {competitions.map(c => (
             <Accordion key={c._id} className="competition-item">
               <AccordionSummary expandIcon="▶">
@@ -424,6 +397,11 @@ export default function Admin() {
           ))}
         </CardContent>
       </Card>
+      <CompetitionWizard
+        open={wizardOpen}
+        onClose={() => setWizardOpen(false)}
+        onCreated={loadCompetitions}
+      />
   </div>
   );
 }

--- a/frontend/src/CompetitionWizard.jsx
+++ b/frontend/src/CompetitionWizard.jsx
@@ -1,0 +1,141 @@
+import { useState, useEffect } from 'react';
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button } from '@mui/material';
+
+const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+export default function CompetitionWizard({ open, onClose, onCreated }) {
+  const [step, setStep] = useState(0);
+  const [name, setName] = useState('');
+  const [groupsCount, setGroupsCount] = useState(1);
+  const [teamsPerGroup, setTeamsPerGroup] = useState(2);
+  const [teams, setTeams] = useState([]);
+
+  useEffect(() => {
+    if (open) {
+      setStep(0);
+      setName('');
+      setGroupsCount(1);
+      setTeamsPerGroup(2);
+      setTeams([]);
+    }
+  }, [open]);
+
+  const updateTeam = (g, t, value) => {
+    setTeams(prev => {
+      const arr = prev.map(row => row.slice());
+      arr[g][t] = value;
+      return arr;
+    });
+  };
+
+  const next = () => {
+    if (step === 0) {
+      const initial = Array.from({ length: groupsCount }, () =>
+        Array.from({ length: teamsPerGroup }, () => '')
+      );
+      setTeams(initial);
+      setStep(1);
+    } else {
+      submit();
+    }
+  };
+
+  const submit = async () => {
+    const matches = [];
+    for (let g = 0; g < groupsCount; g++) {
+      const groupName = `Grupo ${letters[g]}`;
+      for (let i = 0; i < teamsPerGroup; i++) {
+        for (let j = i + 1; j < teamsPerGroup; j++) {
+          matches.push({
+            team1: teams[g][i],
+            team2: teams[g][j],
+            competition: name,
+            group_name: groupName,
+            series: 'Fase de grupos',
+            tournament: name
+          });
+        }
+      }
+    }
+    const data = new FormData();
+    data.append('name', name);
+    data.append('groupsCount', groupsCount);
+    data.append('integrantsPerGroup', teamsPerGroup);
+    const blob = new Blob([JSON.stringify(matches)], { type: 'application/json' });
+    data.append('fixture', blob, 'fixture.json');
+    try {
+      const res = await fetch('/admin/competitions', {
+        method: 'POST',
+        body: data
+      });
+      if (res.ok) {
+        if (onCreated) onCreated();
+        onClose();
+      }
+    } catch (err) {
+      console.error('wizard submit error', err);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Nueva Competencia</DialogTitle>
+      <DialogContent>
+        {step === 0 && (
+          <div>
+            <input
+              type="text"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              placeholder="Nombre"
+              required
+            />
+            <input
+              type="number"
+              value={groupsCount}
+              onChange={e => setGroupsCount(Number(e.target.value))}
+              placeholder="Grupos"
+              style={{ marginLeft: '10px', width: '80px' }}
+              min={1}
+            />
+            <input
+              type="number"
+              value={teamsPerGroup}
+              onChange={e => setTeamsPerGroup(Number(e.target.value))}
+              placeholder="Integrantes"
+              style={{ marginLeft: '10px', width: '100px' }}
+              min={2}
+            />
+          </div>
+        )}
+        {step === 1 && (
+          <div>
+            {teams.map((group, gi) => (
+              <div key={gi} style={{ marginBottom: '1rem' }}>
+                <h6>{`Grupo ${letters[gi]}`}</h6>
+                {group.map((team, ti) => (
+                  <input
+                    key={ti}
+                    type="text"
+                    value={team}
+                    onChange={e => updateTeam(gi, ti, e.target.value)}
+                    placeholder={`Equipo ${ti + 1}`}
+                    style={{ display: 'block', marginBottom: '5px' }}
+                  />
+                ))}
+              </div>
+            ))}
+          </div>
+        )}
+      </DialogContent>
+      <DialogActions>
+        {step === 1 && (
+          <Button onClick={() => setStep(0)}>Atrás</Button>
+        )}
+        <Button onClick={next} variant="contained">
+          {step === 0 ? 'Siguiente' : 'Crear'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- replace simple form with `CompetitionWizard` in admin panel
- generate groups/fixtures via wizard
- submit fixtures as a JSON file to `/admin/competitions`

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876b0f87f90832591d6ef93a4461eae