### PR TITLE
Add public flag for pencas

### DIFF
--- a/frontend/src/Admin.jsx
+++ b/frontend/src/Admin.jsx
@@ -6,7 +6,9 @@ import {
   Accordion,
   AccordionSummary,
   AccordionDetails,
-  Typography
+  Typography,
+  Checkbox,
+  FormControlLabel
 } from '@mui/material';
 import GroupTable from './GroupTable';
 import roundOrder from './roundOrder';
@@ -22,7 +24,7 @@ export default function Admin() {
   const [newCompetition, setNewCompetition] = useState({ name: '', groupsCount: '', integrantsPerGroup: '' });
   const [competitionFile, setCompetitionFile] = useState(null);
   const [ownerForm, setOwnerForm] = useState({ username: '', password: '', email: '' });
-  const [pencaForm, setPencaForm] = useState({ name: '', owner: '', competition: '' });
+  const [pencaForm, setPencaForm] = useState({ name: '', owner: '', competition: '', isPublic: false });
 
   useEffect(() => {
     loadAll();
@@ -197,7 +199,7 @@ export default function Admin() {
         body: data
       });
       if (res.ok) {
-        setPencaForm({ name: '', owner: '', competition: '' });
+        setPencaForm({ name: '', owner: '', competition: '', isPublic: false });
         setPencaFile(null);
         loadPencas();
       }
@@ -212,11 +214,11 @@ export default function Admin() {
 
   async function savePenca(penca) {
     try {
-      const { name, owner, competition, participantLimit } = penca;
+      const { name, owner, competition, participantLimit, isPublic } = penca;
       const res = await fetch(`/admin/pencas/${penca._id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name, owner, competition, participantLimit })
+        body: JSON.stringify({ name, owner, competition, participantLimit, isPublic })
       });
       if (res.ok) loadPencas();
     } catch (err) {
@@ -348,6 +350,11 @@ export default function Admin() {
                 <option key={c._id} value={c.name}>{c.name}</option>
               ))}
             </select>
+            <FormControlLabel
+              control={<Checkbox checked={pencaForm.isPublic} onChange={e => setPencaForm({ ...pencaForm, isPublic: e.target.checked })} />}
+              label="Pública"
+              style={{ marginLeft: '10px' }}
+            />
             <input type="file" accept=".json" onChange={e => setPencaFile(e.target.files[0])} style={{ marginLeft: '10px' }} />
             <Button variant="contained" type="submit" style={{ marginLeft: '10px' }}>Crear</Button>
           </form>
@@ -366,6 +373,11 @@ export default function Admin() {
                     <option key={c._id} value={c.name}>{c.name}</option>
                   ))}
                 </select>
+                <FormControlLabel
+                  control={<Checkbox checked={p.isPublic || false} onChange={e => updatePencaField(p._id, 'isPublic', e.target.checked)} />}
+                  label="Pública"
+                  style={{ marginLeft: '10px' }}
+                />
                 <a href="#" className="secondary-content" onClick={e => { e.preventDefault(); savePenca(p); }}>💾</a>
                 <a href="#" className="secondary-content red-text" style={{ marginLeft: '1rem' }} onClick={e => { e.preventDefault(); deletePenca(p._id); }}>✖</a>
               </li>

--- a/frontend/src/OwnerPanel.jsx
+++ b/frontend/src/OwnerPanel.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Card, CardContent } from '@mui/material';
+import { Card, CardContent, Checkbox, FormControlLabel, Button } from '@mui/material';
 
 export default function OwnerPanel() {
   const [pencas, setPencas] = useState([]);
@@ -65,6 +65,19 @@ export default function OwnerPanel() {
     }
   }
 
+  async function togglePublic(pId, value) {
+    try {
+      const res = await fetch(`/pencas/${pId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ isPublic: value })
+      });
+      if (res.ok) loadData();
+    } catch (err) {
+      console.error('toggle public error', err);
+    }
+  }
+
   const filterMatches = p => {
     let list = [];
     if (Array.isArray(p.fixture) && p.fixture.length) {
@@ -93,7 +106,13 @@ export default function OwnerPanel() {
         return (
           <Card key={p._id} style={{ marginBottom: '1rem', padding: '1rem' }}>
             <CardContent>
-              <strong>{p.name} - {p.code}</strong>
+              <div style={{ display: 'flex', alignItems: 'center' }}>
+                <strong style={{ marginRight: '10px' }}>{p.name} - {p.code}</strong>
+                <FormControlLabel
+                  control={<Checkbox checked={p.isPublic || false} onChange={e => togglePublic(p._id, e.target.checked)} />}
+                  label="Pública"
+                />
+              </div>
               {Object.keys(pMatches)
                 .filter(g => g.startsWith('Grupo'))
                 .sort()

--- a/models/Penca.js
+++ b/models/Penca.js
@@ -6,6 +6,7 @@ const pencaSchema = new mongoose.Schema({
   owner: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   competition: { type: String, required: true },
   participantLimit: { type: Number, default: 20 },
+  isPublic: { type: Boolean, default: false },
   fixture: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Match' }],
   participants: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
   pendingRequests: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }]

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -180,7 +180,7 @@ router.delete('/owners/:id', isAuthenticated, isAdmin, async (req, res) => {
 // Crear penca
 router.post('/pencas', isAuthenticated, isAdmin, jsonUpload.single('fixture'), async (req, res) => {
     try {
-        const { name, owner, participantLimit, competition } = req.body;
+        const { name, owner, participantLimit, competition, isPublic } = req.body;
         if (!name) return res.status(400).json({ error: 'Name required' });
 
         const ownerUser = owner ? await User.findById(owner) : req.session.user;
@@ -199,6 +199,7 @@ router.post('/pencas', isAuthenticated, isAdmin, jsonUpload.single('fixture'), a
             owner: ownerUser._id,
             competition: competition || DEFAULT_COMPETITION,
             participantLimit: participantLimit ? Number(participantLimit) : undefined,
+            isPublic: isPublic === true || isPublic === 'true',
             fixture: fixtureIds,
             participants: []
         });
@@ -230,7 +231,7 @@ router.get('/pencas', isAuthenticated, isAdmin, async (req, res) => {
 // Actualizar penca
 router.put('/pencas/:id', isAuthenticated, isAdmin, async (req, res) => {
     try {
-        const { name, participantLimit, owner, competition } = req.body;
+        const { name, participantLimit, owner, competition, isPublic } = req.body;
         const penca = await Penca.findById(req.params.id);
         if (!penca) return res.status(404).json({ error: 'Penca not found' });
 
@@ -246,6 +247,7 @@ router.put('/pencas/:id', isAuthenticated, isAdmin, async (req, res) => {
         if (name) penca.name = name;
         if (participantLimit !== undefined) penca.participantLimit = Number(participantLimit);
         if (competition) penca.competition = competition;
+        if (isPublic !== undefined) penca.isPublic = isPublic === true || isPublic === 'true';
 
         await penca.save();
         res.json({ message: 'Penca updated' });


### PR DESCRIPTION
## Summary
- allow Penca documents to be marked as public
- support filtering public pencas on `/pencas`
- let owners and admins set the new flag
- expose toggle in admin and owner UIs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876b0f8c4cc8325b381a7a912f5ec63