### PR TITLE
Switch admin & dashboard inputs to MUI

### DIFF
--- a/frontend/src/Admin.jsx
+++ b/frontend/src/Admin.jsx
@@ -420,7 +420,7 @@ export default function Admin() {
               {competitions.map(c => (
                 <MenuItem key={c._id} value={c.name}>{c.name}</MenuItem>
               ))}
-            </select>
+            </Select>
             <FormControlLabel
               control={<Checkbox checked={pencaForm.isPublic} onChange={e => setPencaForm({ ...pencaForm, isPublic: e.target.checked })} />}
               label="Pública"
@@ -464,7 +464,7 @@ export default function Admin() {
                     <MenuItem key={c._id} value={c.name}>{c.name}</MenuItem>
                   ))}
 
-                </select>
+                </Select>
                 <FormControlLabel
                   control={<Checkbox checked={p.isPublic || false} onChange={e => updatePencaField(p._id, 'isPublic', e.target.checked)} />}
                   label="Pública"

--- a/frontend/src/Admin.jsx
+++ b/frontend/src/Admin.jsx
@@ -3,6 +3,9 @@ import {
   Button,
   Card,
   CardContent,
+  TextField,
+  Select,
+  MenuItem,
   Accordion,
   AccordionSummary,
   AccordionDetails,
@@ -286,11 +289,31 @@ export default function Admin() {
         </AccordionSummary>
         <AccordionDetails>
           <form onSubmit={createCompetition} style={{ marginBottom: '1rem' }}>
-            <input type="text" value={newCompetition.name} onChange={e => setNewCompetition({ ...newCompetition, name: e.target.value })} placeholder="Nombre" required />
-            <input type="number" value={newCompetition.groupsCount} onChange={e => setNewCompetition({ ...newCompetition, groupsCount: e.target.value })} placeholder="Grupos" style={{ marginLeft: '10px', width: '80px' }} />
-            <input type="number" value={newCompetition.integrantsPerGroup} onChange={e => setNewCompetition({ ...newCompetition, integrantsPerGroup: e.target.value })} placeholder="Integrantes" style={{ marginLeft: '10px', width: '100px' }} />
+            <TextField
+              value={newCompetition.name}
+              onChange={e => setNewCompetition({ ...newCompetition, name: e.target.value })}
+              label="Nombre"
+              required
+              size="small"
+            />
+            <TextField
+              type="number"
+              value={newCompetition.groupsCount}
+              onChange={e => setNewCompetition({ ...newCompetition, groupsCount: e.target.value })}
+              label="Grupos"
+              size="small"
+              sx={{ ml: 1, width: 80 }}
+            />
+            <TextField
+              type="number"
+              value={newCompetition.integrantsPerGroup}
+              onChange={e => setNewCompetition({ ...newCompetition, integrantsPerGroup: e.target.value })}
+              label="Integrantes"
+              size="small"
+              sx={{ ml: 1, width: 100 }}
+            />
             <input type="file" accept=".json" onChange={e => setCompetitionFile(e.target.files[0])} style={{ marginLeft: '10px' }} />
-            <Button variant="contained" type="submit" style={{ marginLeft: '10px' }}>Crear</Button>
+            <Button variant="contained" type="submit" sx={{ ml: 1 }}>Crear</Button>
           </form>
           {competitions.map(c => (
             <Accordion key={c._id} className="competition-item">
@@ -298,9 +321,25 @@ export default function Admin() {
                 <Typography>{c.name}</Typography>
               </AccordionSummary>
               <AccordionDetails>
-                <input type="text" value={c.name} onChange={e => updateCompetitionField(c._id, 'name', e.target.value)} />
-                <input type="number" value={c.groupsCount ?? ''} onChange={e => updateCompetitionField(c._id, 'groupsCount', e.target.value)} style={{ marginLeft: '10px', width: '80px' }} />
-                <input type="number" value={c.integrantsPerGroup ?? ''} onChange={e => updateCompetitionField(c._id, 'integrantsPerGroup', e.target.value)} style={{ marginLeft: '10px', width: '100px' }} />
+                <TextField
+                  value={c.name}
+                  onChange={e => updateCompetitionField(c._id, 'name', e.target.value)}
+                  size="small"
+                />
+                <TextField
+                  type="number"
+                  value={c.groupsCount ?? ''}
+                  onChange={e => updateCompetitionField(c._id, 'groupsCount', e.target.value)}
+                  size="small"
+                  sx={{ ml: 1, width: 80 }}
+                />
+                <TextField
+                  type="number"
+                  value={c.integrantsPerGroup ?? ''}
+                  onChange={e => updateCompetitionField(c._id, 'integrantsPerGroup', e.target.value)}
+                  size="small"
+                  sx={{ ml: 1, width: 100 }}
+                />
                 <a href="#" className="secondary-content" onClick={e => { e.preventDefault(); saveCompetition(c); }}>💾</a>
                 <a href="#" className="secondary-content red-text" style={{ marginLeft: '1rem' }} onClick={e => { e.preventDefault(); deleteCompetition(c._id); }}>✖</a>
               </AccordionDetails>
@@ -313,16 +352,48 @@ export default function Admin() {
         <CardContent>
           <h6>Owners</h6>
           <form onSubmit={createOwner} style={{ marginBottom: '1rem' }}>
-            <input type="text" value={ownerForm.username} onChange={e => setOwnerForm({ ...ownerForm, username: e.target.value })} placeholder="Username" required />
-            <input type="password" value={ownerForm.password} onChange={e => setOwnerForm({ ...ownerForm, password: e.target.value })} placeholder="Password" required />
-            <input type="email" value={ownerForm.email} onChange={e => setOwnerForm({ ...ownerForm, email: e.target.value })} placeholder="Email" required />
-            <Button variant="contained" type="submit" style={{ marginLeft: '10px' }}>Crear</Button>
+            <TextField
+              value={ownerForm.username}
+              onChange={e => setOwnerForm({ ...ownerForm, username: e.target.value })}
+              label="Username"
+              required
+              size="small"
+            />
+            <TextField
+              type="password"
+              value={ownerForm.password}
+              onChange={e => setOwnerForm({ ...ownerForm, password: e.target.value })}
+              label="Password"
+              required
+              size="small"
+              sx={{ ml: 1 }}
+            />
+            <TextField
+              type="email"
+              value={ownerForm.email}
+              onChange={e => setOwnerForm({ ...ownerForm, email: e.target.value })}
+              label="Email"
+              required
+              size="small"
+              sx={{ ml: 1 }}
+            />
+            <Button variant="contained" type="submit" sx={{ ml: 1 }}>Crear</Button>
           </form>
           <ul className="collection">
             {owners.map(o => (
               <li key={o._id} className="collection-item">
-                <input type="text" value={o.username || ''} onChange={e => updateOwnerField(o._id, 'username', e.target.value)} />
-                <input type="email" value={o.email || ''} onChange={e => updateOwnerField(o._id, 'email', e.target.value)} style={{ marginLeft: '10px' }} />
+                <TextField
+                  value={o.username || ''}
+                  onChange={e => updateOwnerField(o._id, 'username', e.target.value)}
+                  size="small"
+                />
+                <TextField
+                  type="email"
+                  value={o.email || ''}
+                  onChange={e => updateOwnerField(o._id, 'email', e.target.value)}
+                  size="small"
+                  sx={{ ml: 1 }}
+                />
                 <a href="#" className="secondary-content" onClick={e => { e.preventDefault(); saveOwner(o); }}>💾</a>
                 <a href="#" className="secondary-content red-text" style={{ marginLeft: '1rem' }} onClick={e => { e.preventDefault(); deleteOwner(o._id); }}>✖</a>
               </li>
@@ -335,37 +406,76 @@ export default function Admin() {
         <CardContent>
           <h6>Pencas</h6>
           <form onSubmit={createPenca} style={{ marginBottom: '1rem' }}>
-            <input type="text" value={pencaForm.name} onChange={e => setPencaForm({ ...pencaForm, name: e.target.value })} placeholder="Nombre" required />
-            <select value={pencaForm.owner} onChange={e => setPencaForm({ ...pencaForm, owner: e.target.value })} required>
-              <option value="" disabled>Owner</option>
+            <TextField
+              value={pencaForm.name}
+              onChange={e => setPencaForm({ ...pencaForm, name: e.target.value })}
+              label="Nombre"
+              required
+              size="small"
+            />
+            <Select
+              value={pencaForm.owner}
+              onChange={e => setPencaForm({ ...pencaForm, owner: e.target.value })}
+              displayEmpty
+              required
+              size="small"
+              sx={{ ml: 1, minWidth: 120 }}
+            >
+              <MenuItem value="" disabled>Owner</MenuItem>
               {owners.map(o => (
-                <option key={o._id} value={o._id}>{o.username}</option>
+                <MenuItem key={o._id} value={o._id}>{o.username}</MenuItem>
               ))}
-            </select>
-            <select value={pencaForm.competition} onChange={e => setPencaForm({ ...pencaForm, competition: e.target.value })} required style={{ marginLeft: '10px' }}>
-              <option value="" disabled>Competencia</option>
+            </Select>
+            <Select
+              value={pencaForm.competition}
+              onChange={e => setPencaForm({ ...pencaForm, competition: e.target.value })}
+              displayEmpty
+              required
+              size="small"
+              sx={{ ml: 1, minWidth: 120 }}
+            >
+              <MenuItem value="" disabled>Competencia</MenuItem>
               {competitions.map(c => (
-                <option key={c._id} value={c.name}>{c.name}</option>
+                <MenuItem key={c._id} value={c.name}>{c.name}</MenuItem>
               ))}
-            </select>
+            </Select>
             <input type="file" accept=".json" onChange={e => setPencaFile(e.target.files[0])} style={{ marginLeft: '10px' }} />
-            <Button variant="contained" type="submit" style={{ marginLeft: '10px' }}>Crear</Button>
+            <Button variant="contained" type="submit" sx={{ ml: 1 }}>Crear</Button>
           </form>
           <ul className="collection">
             {pencas.map(p => (
               <li key={p._id} className="collection-item">
-                <input type="text" value={p.name || ''} onChange={e => updatePencaField(p._id, 'name', e.target.value)} />
-                <input type="text" value={p.code || ''} readOnly style={{ marginLeft: '10px', width: '90px' }} />
-                <select value={p.owner} onChange={e => updatePencaField(p._id, 'owner', e.target.value)} style={{ marginLeft: '10px' }}>
+                <TextField
+                  value={p.name || ''}
+                  onChange={e => updatePencaField(p._id, 'name', e.target.value)}
+                  size="small"
+                />
+                <TextField
+                  value={p.code || ''}
+                  InputProps={{ readOnly: true }}
+                  size="small"
+                  sx={{ ml: 1, width: 90 }}
+                />
+                <Select
+                  value={p.owner}
+                  onChange={e => updatePencaField(p._id, 'owner', e.target.value)}
+                  size="small"
+                  sx={{ ml: 1, minWidth: 120 }}
+                >
                   {owners.map(o => (
-                    <option key={o._id} value={o._id}>{o.username}</option>
+                    <MenuItem key={o._id} value={o._id}>{o.username}</MenuItem>
                   ))}
-                </select>
-                <select value={p.competition} onChange={e => updatePencaField(p._id, 'competition', e.target.value)} style={{ marginLeft: '10px' }}>
+                </Select>
+                <Select
+                  value={p.competition}
+                  onChange={e => updatePencaField(p._id, 'competition', e.target.value)}
+                  size="small"
+                  sx={{ ml: 1, minWidth: 120 }}
+                >
                   {competitions.map(c => (
-                    <option key={c._id} value={c.name}>{c.name}</option>
+                    <MenuItem key={c._id} value={c.name}>{c.name}</MenuItem>
                   ))}
-                </select>
+                </Select>
                 <a href="#" className="secondary-content" onClick={e => { e.preventDefault(); savePenca(p); }}>💾</a>
                 <a href="#" className="secondary-content red-text" style={{ marginLeft: '1rem' }} onClick={e => { e.preventDefault(); deletePenca(p._id); }}>✖</a>
               </li>
@@ -402,12 +512,45 @@ export default function Admin() {
                         <ul className="collection">
                           {matchesByCompetition[comp][g].map(m => (
                             <li key={m._id} className="collection-item">
-                              <input type="text" value={m.team1 || ''} onChange={e => updateMatchField(m._id, 'team1', e.target.value)} />
-                              <input type="text" value={m.team2 || ''} onChange={e => updateMatchField(m._id, 'team2', e.target.value)} style={{ marginLeft: '10px' }} />
-                              <input type="date" value={m.date || ''} onChange={e => updateMatchField(m._id, 'date', e.target.value)} style={{ marginLeft: '10px' }} />
-                              <input type="time" value={m.time || ''} onChange={e => updateMatchField(m._id, 'time', e.target.value)} style={{ marginLeft: '10px' }} />
-                              <input type="number" value={m.result1 ?? ''} onChange={e => updateMatchField(m._id, 'result1', e.target.value)} style={{ marginLeft: '10px', width: '60px' }} />
-                              <input type="number" value={m.result2 ?? ''} onChange={e => updateMatchField(m._id, 'result2', e.target.value)} style={{ marginLeft: '10px', width: '60px' }} />
+                              <TextField
+                                value={m.team1 || ''}
+                                onChange={e => updateMatchField(m._id, 'team1', e.target.value)}
+                                size="small"
+                              />
+                              <TextField
+                                value={m.team2 || ''}
+                                onChange={e => updateMatchField(m._id, 'team2', e.target.value)}
+                                size="small"
+                                sx={{ ml: 1 }}
+                              />
+                              <TextField
+                                type="date"
+                                value={m.date || ''}
+                                onChange={e => updateMatchField(m._id, 'date', e.target.value)}
+                                size="small"
+                                sx={{ ml: 1 }}
+                              />
+                              <TextField
+                                type="time"
+                                value={m.time || ''}
+                                onChange={e => updateMatchField(m._id, 'time', e.target.value)}
+                                size="small"
+                                sx={{ ml: 1 }}
+                              />
+                              <TextField
+                                type="number"
+                                value={m.result1 ?? ''}
+                                onChange={e => updateMatchField(m._id, 'result1', e.target.value)}
+                                size="small"
+                                sx={{ ml: 1, width: 60 }}
+                              />
+                              <TextField
+                                type="number"
+                                value={m.result2 ?? ''}
+                                onChange={e => updateMatchField(m._id, 'result2', e.target.value)}
+                                size="small"
+                                sx={{ ml: 1, width: 60 }}
+                              />
                               <a href="#" className="secondary-content" onClick={e => { e.preventDefault(); saveMatch(m); }}>💾</a>
                             </li>
                           ))}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,6 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { ThemeProvider, CssBaseline } from '@mui/material';
+import theme from './theme';
 import Login from './Login';
 import Dashboard from './Dashboard';
 import Admin from './Admin';
@@ -8,15 +10,18 @@ import Footer from './Footer';
 
 export default function App() {
   return (
-    <BrowserRouter>
-      <Header />
-      <Routes>
-        <Route path="/" element={<Login />} />
-        <Route path="/dashboard" element={<Dashboard />} />
-        <Route path="/owner" element={<OwnerPanel />} />
-        <Route path="/admin/edit" element={<Admin />} />
-      </Routes>
-      <Footer />
-    </BrowserRouter>
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <BrowserRouter>
+        <Header />
+        <Routes>
+          <Route path="/" element={<Login />} />
+          <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/owner" element={<OwnerPanel />} />
+          <Route path="/admin/edit" element={<Admin />} />
+        </Routes>
+        <Footer />
+      </BrowserRouter>
+    </ThemeProvider>
   );
 }

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import GroupTable from './GroupTable';
 import EliminationBracket from './EliminationBracket';
-import { Button, Card, CardContent } from '@mui/material';
+import { Button, Card, CardContent, TextField } from '@mui/material';
 import MUIBracket from './MUIBracket';
 import roundOrder from './roundOrder';
 
@@ -238,9 +238,23 @@ export default function Dashboard() {
                               <div className="match-details">
                                 <form onSubmit={e => handlePrediction(e, p._id, m._id)}>
                                   <div className="input-field inline">
-                                    <input name="result1" type="number" defaultValue={pr.result1 || ''} required />
+                                    <TextField
+                                      name="result1"
+                                      type="number"
+                                      defaultValue={pr.result1 || ''}
+                                      required
+                                      size="small"
+                                      sx={{ width: 60 }}
+                                    />
                                     <span>-</span>
-                                    <input name="result2" type="number" defaultValue={pr.result2 || ''} required />
+                                    <TextField
+                                      name="result2"
+                                      type="number"
+                                      defaultValue={pr.result2 || ''}
+                                      required
+                                      size="small"
+                                      sx={{ width: 60, ml: 1 }}
+                                    />
                                   </div>
                                   <Button variant="contained" type="submit">Guardar</Button>
                                 </form>
@@ -285,9 +299,23 @@ export default function Dashboard() {
                                   <div className="match-details">
                                     <form onSubmit={e => handlePrediction(e, p._id, m._id)}>
                                       <div className="input-field inline">
-                                        <input name="result1" type="number" defaultValue={pr.result1 || ''} required />
+                                        <TextField
+                                          name="result1"
+                                          type="number"
+                                          defaultValue={pr.result1 || ''}
+                                          required
+                                          size="small"
+                                          sx={{ width: 60 }}
+                                        />
                                         <span>-</span>
-                                        <input name="result2" type="number" defaultValue={pr.result2 || ''} required />
+                                        <TextField
+                                          name="result2"
+                                          type="number"
+                                          defaultValue={pr.result2 || ''}
+                                          required
+                                          size="small"
+                                          sx={{ width: 60, ml: 1 }}
+                                        />
                                       </div>
                                       <Button variant="contained" type="submit">Guardar</Button>
                                     </form>
@@ -330,8 +358,13 @@ export default function Dashboard() {
       {user && user.role === 'user' && (
         <div style={{ marginTop: '2rem' }}>
           <h6>Unirse a una Penca</h6>
-          <input type="text" value={joinCode} onChange={e => setJoinCode(e.target.value)} placeholder="Código" />
-          <Button variant="contained" onClick={handleJoin} style={{ marginLeft: '10px' }}>Solicitar</Button>
+          <TextField
+            value={joinCode}
+            onChange={e => setJoinCode(e.target.value)}
+            label="Código"
+            size="small"
+          />
+          <Button variant="contained" onClick={handleJoin} sx={{ ml: 1 }}>Solicitar</Button>
           {joinMsg && <div style={{ marginTop: '0.5rem' }}>{joinMsg}</div>}
         </div>
       )}

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -1,0 +1,33 @@
+import { createTheme } from '@mui/material/styles';
+
+const theme = createTheme({
+  palette: {
+    primary: {
+      main: '#6200ee',
+      contrastText: '#ffffff'
+    },
+    secondary: {
+      main: '#03dac6',
+      contrastText: '#000000'
+    },
+    background: {
+      default: '#f5f5f5',
+      paper: '#ffffff'
+    },
+    error: {
+      main: '#b00020',
+      contrastText: '#ffffff'
+    },
+    text: {
+      primary: '#000000'
+    }
+  },
+  shape: {
+    borderRadius: 8
+  },
+  typography: {
+    fontFamily: "'Roboto', sans-serif"
+  }
+});
+
+export default theme;

--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -37,26 +37,6 @@ h3 {
     color: #002f6c; /* Azul oscuro */
 }
 
-.input-field {
-    margin-bottom: 20px;
-}
-
-.btn {
-    background-color: #ffd100; /* Amarillo */
-    border-radius: 25px;
-}
-
-.btn:hover {
-    background-color: #e6b800; /* Amarillo más oscuro */
-}
-
-.file-field .btn {
-    background-color: #002f6c; /* Azul oscuro */
-}
-
-.file-field .btn:hover {
-    background-color: #001c48; /* Azul oscuro más oscuro */
-}
 
 .tabs .tab a {
     color: #002f6c; /* Azul oscuro */

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -141,23 +141,7 @@ footer {
     margin-right: 5px;
 }
 
-.input-field.inline input {
-    width: 50px;
-    margin-right: 5px;
-    text-align: center;
-}
-
 /* === Buttons & Tabs === */
-.btn {
-    background-color: #6200ee;
-    color: #ffffff;
-    border-radius: 8px;
-    transition: background-color 0.3s ease;
-}
-
-.btn:hover {
-    background-color: #5800d6;
-}
 
 .tabs .tab a {
     color: #002f6c;
@@ -210,13 +194,6 @@ footer {
     text-align: center;
 }
 
-.login-container .input-field {
-    margin-bottom: 20px;
-}
-
-.login-container .btn {
-    width: 100%;
-}
 
 /* === Modal === */
 .modal {
@@ -271,9 +248,6 @@ footer {
     height: 60px;
 }
 
-.btn-block {
-    width: 100%;
-}
 
 .collection-item.rank-1 {
     background: linear-gradient(to right, #ffe082, #fff8e1);
@@ -356,8 +330,3 @@ footer {
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
-.input-field input {
-    border-radius: 8px;
-    border: 1px solid #ccc;
-    padding: 0.5rem;
-}


### PR DESCRIPTION
## Summary
- theme all components with new MUI theme
- use MUI TextField and Select for admin and dashboard forms
- wrap the app in ThemeProvider
- drop old CSS for custom inputs/buttons

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876b0fb17888325bfa930876aee8199