### PR TITLE
Allow CSV uploads for teams in wizard

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -27,10 +27,11 @@ const upload = multer({
 const jsonUpload = multer({
     storage: multer.memoryStorage(),
     fileFilter: (req, file, cb) => {
-        if (file.mimetype === 'application/json') {
+        const allowed = ['application/json', 'text/csv'];
+        if (allowed.includes(file.mimetype)) {
             cb(null, true);
         } else {
-            cb(new Error('Solo se permiten archivos JSON'));
+            cb(new Error('Solo se permiten archivos JSON o CSV'));
         }
     }
 });


### PR DESCRIPTION
## Summary
- accept CSV files when uploading JSON fixtures
- allow uploading team lists in the wizard
- auto-split uploaded list into groups
- keep prepopulated teams when moving to the next step

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: network access denied)*

------
https://chatgpt.com/codex/tasks/task_e_6877cd06ce3c83258647ce9de14c1d85