### PR TITLE
Add wizard opener button for competitions

### DIFF
--- a/frontend/src/Admin.jsx
+++ b/frontend/src/Admin.jsx
@@ -322,6 +322,7 @@ export default function Admin() {
             />
             <input type="file" accept=".json" onChange={e => setCompetitionFile(e.target.files[0])} style={{ marginLeft: '10px' }} />
             <Button variant="contained" type="submit" sx={{ ml: 1 }}>Crear</Button>
+            <Button variant="contained" type="button" onClick={() => setWizardOpen(true)} sx={{ ml: 1 }}>Usar asistente</Button>
           </form>
 
           {competitions.map(c => (


### PR DESCRIPTION
## Summary
- add a button in the Competencias admin section to launch the competition wizard

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68790c0a7de0832597219178ec65d247