### PR TITLE
Display matches within competition accordion

### DIFF
--- a/routes/matches.js
+++ b/routes/matches.js
@@ -11,7 +11,16 @@ router.get('/', async (req, res) => {
     } catch (err) {
         res.status(500).json({ error: 'Error retrieving matches' });
     }
-}); 
+});
+
+router.get('/competition/:competition', async (req, res) => {
+    try {
+        const matches = await Match.find({ competition: req.params.competition });
+        res.json(matches);
+    } catch (err) {
+        res.status(500).json({ error: 'Error retrieving matches' });
+    }
+});
  
 router.post('/:id', isAdmin, async (req, res) => {
     try {


### PR DESCRIPTION
## Summary
- remove old Matches card from admin page
- display matches inside each competition's accordion
- fetch matches per competition lazily
- expose `/matches/competition/:competition` endpoint

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687915fd41808325ae7ad8500f1b1a6d