### PR TITLE
Handle competition-specific match data

### DIFF
--- a/routes/matches.js
+++ b/routes/matches.js
@@ -11,7 +11,17 @@ router.get('/', async (req, res) => {
     } catch (err) {
         res.status(500).json({ error: 'Error retrieving matches' });
     }
-}); 
+});
+
+// Matches for a specific competition
+router.get('/competition/:competition', async (req, res) => {
+    try {
+        const matches = await Match.find({ competition: req.params.competition });
+        res.json(matches);
+    } catch (err) {
+        res.status(500).json({ error: 'Error retrieving matches' });
+    }
+});
  
 router.post('/:id', isAdmin, async (req, res) => {
     try {


### PR DESCRIPTION
## Summary
- add endpoint to fetch matches by competition
- load matches per competition in Dashboard
- load matches per competition in OwnerPanel

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687915ffd9208325b10e02394953bb2f