### PR TITLE
Add competitions matches endpoint

### DIFF
--- a/main.js
+++ b/main.js
@@ -98,6 +98,7 @@ const Match = require('./models/Match');
 const Prediction = require('./models/Prediction');
 const adminRouter = require('./routes/admin');
 const pencaRouter = require('./routes/penca');
+const competitionsRouter = require('./routes/competitions');
 
 async function initializeDatabase() {
     try {
@@ -327,6 +328,7 @@ app.use('/groups', isAuthenticated, require('./routes/groups').router);
 app.use('/bracket', isAuthenticated, require('./routes/bracket'));
 app.use('/pencas', isAuthenticated, pencaRouter);
 app.use('/admin', adminRouter);
+app.use('/competitions', competitionsRouter);
 
 app.post('/logout', (req, res) => {
     req.session.destroy(err => {

--- a/routes/competitions.js
+++ b/routes/competitions.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = express.Router();
+const Match = require('../models/Match');
+
+router.get('/:competition/matches', async (req, res) => {
+  const matches = await Match.find({ competition: req.params.competition });
+  res.json(matches);
+});
+
+module.exports = router;

--- a/tests/competitions.route.test.js
+++ b/tests/competitions.route.test.js
@@ -1,0 +1,24 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../models/Match', () => ({ find: jest.fn() }));
+
+const Match = require('../models/Match');
+const competitionsRouter = require('../routes/competitions');
+
+describe('Competitions Routes', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('lists matches for a competition', async () => {
+    Match.find.mockResolvedValue([{ _id: 'm1' }]);
+
+    const app = express();
+    app.use('/competitions', competitionsRouter);
+
+    const res = await request(app).get('/competitions/c1/matches');
+
+    expect(res.status).toBe(200);
+    expect(Match.find).toHaveBeenCalledWith({ competition: 'c1' });
+    expect(res.body[0]._id).toBe('m1');
+  });
+});


### PR DESCRIPTION
## Summary
- add `routes/competitions.js` with matches endpoint
- mount competitions router in `main.js`
- test competitions route

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68791f8ecee88325b1599b7be9ea7fc4