### PR TITLE
Use competition-specific matches API

### DIFF
--- a/frontend/src/Admin.jsx
+++ b/frontend/src/Admin.jsx
@@ -41,7 +41,8 @@ export default function Admin() {
   }, []);
 
   async function loadAll() {
-    await Promise.all([loadCompetitions(), loadOwners(), loadPencas(), loadMatches()]);
+    await Promise.all([loadCompetitions(), loadOwners(), loadPencas()]);
+    await loadMatches();
   }
 
   async function loadCompetitions() {
@@ -73,13 +74,17 @@ export default function Admin() {
 
   async function loadMatches() {
     try {
-      const res = await fetch('/matches');
-      if (res.ok) {
-        const data = await res.json();
-        setMatches(data);
-        const comps = Array.from(new Set(data.map(m => m.competition)));
-        if (comps.length) await loadGroups(comps);
+      const comps = competitions.map(c => c.name);
+      const data = [];
+      for (const c of comps) {
+        const r = await fetch(`/competitions/${encodeURIComponent(c)}/matches`);
+        if (r.ok) {
+          const list = await r.json();
+          data.push(...list);
+        }
       }
+      setMatches(data);
+      if (comps.length) await loadGroups(comps);
     } catch (err) {
       console.error('load matches error', err);
     }

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -39,16 +39,19 @@ export default function Dashboard() {
     async function loadData() {
       if (!pencas.length) return;
       try {
-        const [mRes, pRes] = await Promise.all([
-          fetch('/matches'),
-          fetch('/predictions')
-        ]);
-        if (mRes.ok) {
-          const data = await mRes.json();
-          setMatches(data);
-          const comps = Array.from(new Set(data.map(m => m.competition)));
-          if (comps.length) await loadGroups(comps);
+        const comps = Array.from(new Set(pencas.map(p => p.competition)));
+        const matchesData = [];
+        for (const c of comps) {
+          const r = await fetch(`/competitions/${encodeURIComponent(c)}/matches`);
+          if (r.ok) {
+            const list = await r.json();
+            matchesData.push(...list);
+          }
         }
+        setMatches(matchesData);
+        if (comps.length) await loadGroups(comps);
+
+        const pRes = await fetch('/predictions');
         if (pRes.ok) setPreds(await pRes.json());
         pencas.forEach(p => loadRanking(p._id));
         if (user && user.role === 'owner') loadOwnerPencas();

--- a/frontend/src/OwnerPanel.jsx
+++ b/frontend/src/OwnerPanel.jsx
@@ -13,8 +13,16 @@ export default function OwnerPanel() {
   useEffect(() => {
     async function loadMatches() {
       try {
-        const res = await fetch('/matches');
-        if (res.ok) setMatches(await res.json());
+        const comps = Array.from(new Set(pencas.map(p => p.competition)));
+        const data = [];
+        for (const c of comps) {
+          const r = await fetch(`/competitions/${encodeURIComponent(c)}/matches`);
+          if (r.ok) {
+            const list = await r.json();
+            data.push(...list);
+          }
+        }
+        setMatches(data);
       } catch (err) {
         console.error('load matches error', err);
       }


### PR DESCRIPTION
## Summary
- fetch matches per competition in Dashboard, OwnerPanel and Admin
- adjust admin load order to load matches after competitions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68791f9208988325ba652421baf69e27