### PR TITLE
Remove penca fixture upload

### DIFF
--- a/frontend/src/Admin.jsx
+++ b/frontend/src/Admin.jsx
@@ -197,21 +197,16 @@ export default function Admin() {
     }
   }
 
-  const [pencaFile, setPencaFile] = useState(null);
-
   async function createPenca(e) {
     e.preventDefault();
     try {
-      const data = new FormData();
-      Object.entries(pencaForm).forEach(([k, v]) => data.append(k, v));
-      if (pencaFile) data.append('fixture', pencaFile);
       const res = await fetch('/admin/pencas', {
         method: 'POST',
-        body: data
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(pencaForm)
       });
       if (res.ok) {
         setPencaForm({ name: '', owner: '', competition: '', isPublic: false });
-        setPencaFile(null);
         loadPencas();
       }
     } catch (err) {
@@ -541,7 +536,6 @@ export default function Admin() {
               style={{ marginLeft: '10px' }}
             />
 
-            <input type="file" accept=".json" onChange={e => setPencaFile(e.target.files[0])} style={{ marginLeft: '10px' }} />
             <Button variant="contained" type="submit" sx={{ ml: 1 }}>Crear</Button>
           </form>
           <ul className="collection">

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -179,7 +179,7 @@ router.delete('/owners/:id', isAuthenticated, isAdmin, async (req, res) => {
 });
 
 // Crear penca
-router.post('/pencas', isAuthenticated, isAdmin, jsonUpload.single('fixture'), async (req, res) => {
+router.post('/pencas', isAuthenticated, isAdmin, async (req, res) => {
     try {
         const { name, owner, participantLimit, competition, isPublic } = req.body;
         if (!name) return res.status(400).json({ error: 'Name required' });
@@ -188,11 +188,6 @@ router.post('/pencas', isAuthenticated, isAdmin, jsonUpload.single('fixture'), a
         if (!ownerUser) return res.status(404).json({ error: 'Owner not found' });
 
         let fixtureIds = [];
-        if (req.file) {
-            const matchesData = JSON.parse(req.file.buffer.toString());
-            const created = await Match.insertMany(matchesData);
-            fixtureIds = created.map(m => m._id);
-        }
 
         const penca = new Penca({
             name,

--- a/tests/admin.test.js
+++ b/tests/admin.test.js
@@ -57,22 +57,16 @@ const adminRouter = require('../routes/admin');
 describe('Admin penca creation', () => {
   afterEach(() => jest.clearAllMocks());
 
-  it('creates a penca and loads matches', async () => {
+  it('creates a penca', async () => {
     User.findById.mockResolvedValue({ _id: 'u1', ownedPencas: [], save: jest.fn().mockResolvedValue(true) });
-    Match.insertMany.mockResolvedValue([{ _id: 'm1' }]);
 
     const app = express();
+    app.use(express.json());
     app.use('/admin', adminRouter);
-
-    const fixture = [{ team1: 'A', team2: 'B' }];
 
     const res = await request(app)
       .post('/admin/pencas')
-      .field('name', 'Test')
-      .field('owner', 'u1')
-      .field('participantLimit', '10')
-      .field('competition', 'Comp1')
-      .attach('fixture', Buffer.from(JSON.stringify(fixture)), 'fixture.json');
+      .send({ name: 'Test', owner: 'u1', participantLimit: '10', competition: 'Comp1' });
 
     expect(res.status).toBe(201);
     expect(Penca).toHaveBeenCalledWith(expect.objectContaining({
@@ -81,7 +75,7 @@ describe('Admin penca creation', () => {
       participantLimit: 10,
       competition: 'Comp1'
     }));
-    expect(Match.insertMany).toHaveBeenCalled();
+    expect(Match.insertMany).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- stop processing `fixture` uploads when creating a new penca
- drop file handling from admin UI and unit tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687975b6fc988325a24e4ede63f20a31