### PR TITLE
Remove unused fixture upload

### DIFF
--- a/frontend/src/Admin.jsx
+++ b/frontend/src/Admin.jsx
@@ -35,7 +35,6 @@ export default function Admin() {
     groupsCount: '',
     integrantsPerGroup: ''
   });
-  const [competitionFile, setCompetitionFile] = useState(null);
 
   useEffect(() => {
     loadAll();
@@ -136,16 +135,13 @@ export default function Admin() {
   async function createCompetition(e) {
     e.preventDefault();
     try {
-      const data = new FormData();
-      Object.entries(newCompetition).forEach(([k, v]) => data.append(k, v));
-      if (competitionFile) data.append('fixture', competitionFile);
       const res = await fetch('/admin/competitions', {
         method: 'POST',
-        body: data
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(newCompetition)
       });
       if (res.ok) {
         setNewCompetition({ name: '', groupsCount: '', integrantsPerGroup: '' });
-        setCompetitionFile(null);
         loadCompetitions();
       }
     } catch (err) {
@@ -319,7 +315,6 @@ export default function Admin() {
               size="small"
               sx={{ ml: 1, width: 100 }}
             />
-            <input type="file" accept=".json" onChange={e => setCompetitionFile(e.target.files[0])} style={{ marginLeft: '10px' }} />
             <Button variant="contained" type="submit" sx={{ ml: 1 }}>Crear</Button>
             <Button variant="contained" type="button" onClick={() => setWizardOpen(true)} sx={{ ml: 1 }}>Usar asistente</Button>
           </form>

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -273,7 +273,7 @@ router.delete('/pencas/:id', isAuthenticated, isAdmin, async (req, res) => {
 });
 
 // Crear competencia
-router.post('/competitions', isAuthenticated, isAdmin, jsonUpload.single('fixture'), async (req, res) => {
+router.post('/competitions', isAuthenticated, isAdmin, async (req, res) => {
     try {
         const { name, useApi, groupsCount, integrantsPerGroup } = req.body;
         if (!name) return res.status(400).json({ error: 'Name required' });
@@ -285,11 +285,7 @@ router.post('/competitions', isAuthenticated, isAdmin, jsonUpload.single('fixtur
         });
         await competition.save();
 
-        if (req.file) {
-            const matchesData = JSON.parse(req.file.buffer.toString());
-            matchesData.forEach(m => { if (!m.competition) m.competition = name; });
-            await Match.insertMany(matchesData);
-        } else if (String(useApi) === 'true') {
+        if (String(useApi) === 'true') {
             const {
                 FOOTBALL_API_KEY,
                 FOOTBALL_LEAGUE_ID,

--- a/tests/admin.test.js
+++ b/tests/admin.test.js
@@ -105,22 +105,19 @@ describe('Admin penca listing', () => {
 describe('Admin competition creation', () => {
   afterEach(() => jest.clearAllMocks());
 
-  it('creates a competition with fixture', async () => {
+  it('creates a competition', async () => {
     Match.insertMany.mockResolvedValue([{ _id: 'm1' }]);
 
     const app = express();
+    app.use(express.json());
     app.use('/admin', adminRouter);
-
-    const fixture = [{ team1: 'A', team2: 'B' }];
 
     const res = await request(app)
       .post('/admin/competitions')
-      .field('name', 'Copa Test')
-      .attach('fixture', Buffer.from(JSON.stringify(fixture)), 'fixture.json');
+      .send({ name: 'Copa Test', groupsCount: 1, integrantsPerGroup: 2 });
 
     expect(res.status).toBe(201);
     expect(Competition).toHaveBeenCalledWith(expect.objectContaining({ name: 'Copa Test' }));
-    expect(Match.insertMany).toHaveBeenCalled();
   });
 
   it('lists competitions', async () => {


### PR DESCRIPTION
## Summary
- drop fixture upload from competition creation endpoint
- update Admin UI to remove file inputs
- simplify competition wizard to send JSON only
- adjust tests for new competition create flow

## Testing
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_687975b715e88325b0fd886a6b6bd0a5