### PR TITLE
Load matches after penca creation

### DIFF
--- a/frontend/src/Admin.jsx
+++ b/frontend/src/Admin.jsx
@@ -210,6 +210,8 @@ export default function Admin() {
         body: data
       });
       if (res.ok) {
+        const comp = competitions.find(c => c.name === pencaForm.competition);
+        if (comp) loadCompetitionMatches(comp);
         setPencaForm({ name: '', owner: '', competition: '', isPublic: false });
         setPencaFile(null);
         loadPencas();


### PR DESCRIPTION
## Summary
- refresh matches for selected competition after creating a penca

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687975bc73ec83258bbd6804b3393fe8