### PR TITLE
Revise admin creation tests

### DIFF
--- a/tests/admin.test.js
+++ b/tests/admin.test.js
@@ -57,22 +57,19 @@ const adminRouter = require('../routes/admin');
 describe('Admin penca creation', () => {
   afterEach(() => jest.clearAllMocks());
 
-  it('creates a penca and loads matches', async () => {
+  it('creates a penca without fixture', async () => {
     User.findById.mockResolvedValue({ _id: 'u1', ownedPencas: [], save: jest.fn().mockResolvedValue(true) });
     Match.insertMany.mockResolvedValue([{ _id: 'm1' }]);
 
     const app = express();
     app.use('/admin', adminRouter);
 
-    const fixture = [{ team1: 'A', team2: 'B' }];
-
     const res = await request(app)
       .post('/admin/pencas')
       .field('name', 'Test')
       .field('owner', 'u1')
       .field('participantLimit', '10')
-      .field('competition', 'Comp1')
-      .attach('fixture', Buffer.from(JSON.stringify(fixture)), 'fixture.json');
+      .field('competition', 'Comp1');
 
     expect(res.status).toBe(201);
     expect(Penca).toHaveBeenCalledWith(expect.objectContaining({
@@ -81,7 +78,7 @@ describe('Admin penca creation', () => {
       participantLimit: 10,
       competition: 'Comp1'
     }));
-    expect(Match.insertMany).toHaveBeenCalled();
+    expect(Match.insertMany).not.toHaveBeenCalled();
   });
 });
 
@@ -105,22 +102,19 @@ describe('Admin penca listing', () => {
 describe('Admin competition creation', () => {
   afterEach(() => jest.clearAllMocks());
 
-  it('creates a competition with fixture', async () => {
+  it('creates a competition', async () => {
     Match.insertMany.mockResolvedValue([{ _id: 'm1' }]);
 
     const app = express();
     app.use('/admin', adminRouter);
 
-    const fixture = [{ team1: 'A', team2: 'B' }];
-
     const res = await request(app)
       .post('/admin/competitions')
-      .field('name', 'Copa Test')
-      .attach('fixture', Buffer.from(JSON.stringify(fixture)), 'fixture.json');
+      .field('name', 'Copa Test');
 
     expect(res.status).toBe(201);
     expect(Competition).toHaveBeenCalledWith(expect.objectContaining({ name: 'Copa Test' }));
-    expect(Match.insertMany).toHaveBeenCalled();
+    expect(Match.insertMany).not.toHaveBeenCalled();
   });
 
   it('lists competitions', async () => {


### PR DESCRIPTION
## Summary
- update admin penca creation test to no longer send a fixture
- update admin competition creation test to skip fixture upload
- expect `Match.insertMany` not to be called when no fixtures are provided

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687975bf26208325a6bf9a60a21c4e8d