### PR TITLE
Refactor: remove unused jsonUpload middleware

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -24,17 +24,6 @@ const upload = multer({
     }
 });
  
-const jsonUpload = multer({
-    storage: multer.memoryStorage(),
-    fileFilter: (req, file, cb) => {
-        const allowed = ['application/json', 'text/csv'];
-        if (allowed.includes(file.mimetype)) {
-            cb(null, true);
-        } else {
-            cb(new Error('Solo se permiten archivos JSON o CSV'));
-        }
-    }
-});
 
 // Página de administración
 router.get('/edit', isAuthenticated, isAdmin, async (req, res) => {
@@ -179,7 +168,7 @@ router.delete('/owners/:id', isAuthenticated, isAdmin, async (req, res) => {
 });
 
 // Crear penca
-router.post('/pencas', isAuthenticated, isAdmin, jsonUpload.single('fixture'), async (req, res) => {
+router.post('/pencas', isAuthenticated, isAdmin, async (req, res) => {
     try {
         const { name, owner, participantLimit, competition, isPublic } = req.body;
         if (!name) return res.status(400).json({ error: 'Name required' });
@@ -273,7 +262,7 @@ router.delete('/pencas/:id', isAuthenticated, isAdmin, async (req, res) => {
 });
 
 // Crear competencia
-router.post('/competitions', isAuthenticated, isAdmin, jsonUpload.single('fixture'), async (req, res) => {
+router.post('/competitions', isAuthenticated, isAdmin, async (req, res) => {
     try {
         const { name, useApi, groupsCount, integrantsPerGroup } = req.body;
         if (!name) return res.status(400).json({ error: 'Name required' });


### PR DESCRIPTION
## Summary
- remove `jsonUpload` definition and references
- clean up admin routes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687975c0508c8325a2817c99d809cc43