### PR TITLE
Enable wizard-only competitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ Si no defines `SESSION_SECRET`, el servidor se cerrará al iniciarse.
 El valor `MAX_PENCAS_PER_USER` controla cuántas pencas puede integrar cada usuario,
 útil si planeas varias competiciones en paralelo.
 
-La variable `DEFAULT_COMPETITION` define el nombre de la competencia principal. Al
-iniciar la aplicación se creará automáticamente si aún no existe y se asignará por
-defecto a los usuarios y puntajes nuevos.
+La variable `DEFAULT_COMPETITION` define el nombre de la competencia principal.
+Debes crearla desde el asistente de competencias en el panel de administración
+para que pueda asignarse por defecto a nuevos usuarios y puntajes.
 
 3. Inicia el servidor en modo desarrollo con **nodemon**:
 

--- a/frontend/src/Admin.jsx
+++ b/frontend/src/Admin.jsx
@@ -30,11 +30,6 @@ export default function Admin() {
   const [ownerForm, setOwnerForm] = useState({ username: '', password: '', email: '' });
   const [pencaForm, setPencaForm] = useState({ name: '', owner: '', competition: '', isPublic: false });
 
-  const [newCompetition, setNewCompetition] = useState({
-    name: '',
-    groupsCount: '',
-    integrantsPerGroup: ''
-  });
 
   useEffect(() => {
     loadAll();
@@ -132,22 +127,6 @@ export default function Admin() {
     }
   }
 
-  async function createCompetition(e) {
-    e.preventDefault();
-    try {
-      const res = await fetch('/admin/competitions', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(newCompetition)
-      });
-      if (res.ok) {
-        setNewCompetition({ name: '', groupsCount: '', integrantsPerGroup: '' });
-        loadCompetitions();
-      }
-    } catch (err) {
-      console.error('create competition error', err);
-    }
-  }
 
   async function createOwner(e) {
     e.preventDefault();
@@ -283,38 +262,12 @@ export default function Admin() {
     <div className="container" style={{ marginTop: '2rem' }}>
       <h5>Administración</h5>
 
-      <Accordion className="admin-accordion" style={{ marginTop: '2rem' }}>
-        <AccordionSummary expandIcon="▶">
-          <Typography variant="subtitle1">Competencias</Typography>
-        </AccordionSummary>
-        <AccordionDetails>
-          <form onSubmit={createCompetition} style={{ marginBottom: '1rem' }}>
-            <TextField
-              value={newCompetition.name}
-              onChange={e => setNewCompetition({ ...newCompetition, name: e.target.value })}
-              label="Nombre"
-              required
-              size="small"
-            />
-            <TextField
-              type="number"
-              value={newCompetition.groupsCount}
-              onChange={e => setNewCompetition({ ...newCompetition, groupsCount: e.target.value })}
-              label="Grupos"
-              size="small"
-              sx={{ ml: 1, width: 80 }}
-            />
-            <TextField
-              type="number"
-              value={newCompetition.integrantsPerGroup}
-              onChange={e => setNewCompetition({ ...newCompetition, integrantsPerGroup: e.target.value })}
-              label="Integrantes"
-              size="small"
-              sx={{ ml: 1, width: 100 }}
-            />
-            <Button variant="contained" type="submit" sx={{ ml: 1 }}>Crear</Button>
-            <Button variant="contained" type="button" onClick={() => setWizardOpen(true)} sx={{ ml: 1 }}>Usar asistente</Button>
-          </form>
+      <Card style={{ marginTop: '2rem', padding: '1rem' }}>
+        <CardContent>
+          <h6>Competencias</h6>
+          <Button variant="contained" type="button" onClick={() => setWizardOpen(true)} sx={{ mb: 2 }}>
+            Nueva competencia
+          </Button>
 
           {competitions.map(c => (
             <Accordion
@@ -429,11 +382,9 @@ export default function Admin() {
                   );
                 })}
 
-              </AccordionDetails>
-            </Accordion>
-          ))}
-        </AccordionDetails>
-      </Accordion>
+              ))}
+        </CardContent>
+      </Card>
 
       <Card style={{ marginTop: '2rem', padding: '1rem' }}>
         <CardContent>

--- a/main.js
+++ b/main.js
@@ -10,7 +10,6 @@ const MongoStore = require('connect-mongo');
 const { isAuthenticated, isAdmin } = require('./middleware/auth');
 const cacheControl = require('./middleware/cacheControl');
 const { DEFAULT_COMPETITION } = require('./config');
-const Competition = require('./models/Competition');
 const Penca = require("./models/Penca");
 
 dotenv.config();
@@ -112,14 +111,7 @@ async function initializeDatabase() {
             process.exit(1);
         }
 
-        // Asegurar que exista la competencia por defecto
-        let competition = await Competition.findOne({ name: DEFAULT_COMPETITION });
-        if (!competition) {
-            competition = new Competition({ name: DEFAULT_COMPETITION });
-            await competition.save();
-            debugLog(`Competencia creada: ${DEFAULT_COMPETITION}`);
-        }
-
+        // Crear usuario administrador si no existe
         let admin = await User.findOne({ username: adminUsername });
         if (!admin) {
             debugLog('No existe usuario administrador, creándolo...');
@@ -132,7 +124,7 @@ async function initializeDatabase() {
                 valid: true
             });
             await admin.save();
-            await Score.create({ userId: admin._id, competition: competition.name });
+            await Score.create({ userId: admin._id, competition: DEFAULT_COMPETITION });
             debugLog('Usuario administrador creado.');
         }
         // Los partidos deben cargarse manualmente desde las herramientas de administración


### PR DESCRIPTION
## Summary
- prevent auto creation of default competition
- update README to note competitions must be created via the assistant
- refactor admin frontend so "Competencias" is a card and creation only uses the wizard

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68797e8cd9fc8325974655775134b052