### PR TITLE
Fix admin result loading and login header

### DIFF
--- a/frontend/src/Admin.jsx
+++ b/frontend/src/Admin.jsx
@@ -66,7 +66,7 @@ export default function Admin() {
 
   async function loadCompetitionMatches(comp) {
     try {
-      const res = await fetch(`/admin/competitions/${comp._id}/matches`);
+      const res = await fetch(`/admin/competitions/${encodeURIComponent(comp.name)}/matches`);
       if (!res.ok) return;
       const data = await res.json();
       setMatchesByCompetition(ms => ({ ...ms, [comp._id]: data }));
@@ -232,7 +232,7 @@ export default function Admin() {
   async function saveMatch(compId, match) {
     try {
       const { team1, team2, date, time } = match;
-      const resInfo = await fetch(`/admin/competitions/${compId}/matches/${match._id}`, {
+      const resInfo = await fetch(`/admin/competitions/${encodeURIComponent(match.competition)}/matches/${match._id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ team1, team2, date, time }),
@@ -240,7 +240,7 @@ export default function Admin() {
 
       const res1 = match.result1 === '' ? null : Number(match.result1);
       const res2 = match.result2 === '' ? null : Number(match.result2);
-      const resScore = await fetch(`/admin/competitions/${compId}/matches/${match._id}`, {
+      const resScore = await fetch(`/admin/competitions/${encodeURIComponent(match.competition)}/matches/${match._id}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ result1: res1, result2: res2 }),

--- a/frontend/src/Header.jsx
+++ b/frontend/src/Header.jsx
@@ -1,8 +1,9 @@
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { Button } from '@mui/material';
 
 export default function Header() {
   const navigate = useNavigate();
+  const location = useLocation();
 
   const handleLogout = async () => {
     try {
@@ -19,9 +20,11 @@ export default function Header() {
         <Link to="/" className="logo">
           <img src="/images/Logo.png" alt="Logo" className="logo-img" />
         </Link>
-        <Button variant="contained" color="secondary" onClick={handleLogout}>
-          Logout
-        </Button>
+        {location.pathname !== '/' && (
+          <Button variant="contained" color="secondary" onClick={handleLogout}>
+            Logout
+          </Button>
+        )}
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- load match data by competition name instead of id
- hide logout button when on the login page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687984e8745c832598efc5aaaebecef8