### PR TITLE
Add knockout placeholders on competition creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Con esta estructura puedes navegar fácilmente por cada componente de la aplicac
 
 Dentro del panel de administración (`/admin/edit`) encontrarás la sección **Competencias**. Haz clic en el botón **Nueva competencia** para abrir el asistente. Allí podrás indicar la cantidad de grupos y equipos por grupo o cargar un archivo de fixture.
 
+Si generas los encuentros de la fase de grupos desde aquí sin usar un fixture externo, la aplicación añadirá automáticamente las llaves de eliminación. Para torneos con 4 grupos se crean los cruces de cuartos, semifinales, tercer puesto y final. En competencias con más de cuatro grupos también se generan los enfrentamientos de “Ronda de 32”.
+
 Para replicar el Mundial 2026 utiliza el archivo `worldcup2026_placeholder.json` incluido en la raíz del repositorio al momento de cargar el fixture. Configura además `DEFAULT_COMPETITION=Mundial 2026` en tu archivo `.env` para que la aplicación asigne ese torneo por defecto.
 
 ## Administración de resultados

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -328,6 +328,46 @@ router.post('/competitions', isAuthenticated, isAdmin, async (req, res) => {
             }
             if (matches.length) {
                 await Match.insertMany(matches);
+
+                if (competition.groupsCount === 4) {
+                    const elim = [
+                        { team1: 'Ganador A', team2: 'Segundo B', competition: name, group_name: 'Cuartos de final', series: 'Eliminatorias', tournament: name },
+                        { team1: 'Ganador B', team2: 'Segundo A', competition: name, group_name: 'Cuartos de final', series: 'Eliminatorias', tournament: name },
+                        { team1: 'Ganador C', team2: 'Segundo D', competition: name, group_name: 'Cuartos de final', series: 'Eliminatorias', tournament: name },
+                        { team1: 'Ganador D', team2: 'Segundo C', competition: name, group_name: 'Cuartos de final', series: 'Eliminatorias', tournament: name },
+                        { team1: 'Semifinal 1', team2: 'Semifinal 2', competition: name, group_name: 'Semifinales', series: 'Eliminatorias', tournament: name },
+                        { team1: 'Semifinal 3', team2: 'Semifinal 4', competition: name, group_name: 'Semifinales', series: 'Eliminatorias', tournament: name },
+                        { team1: 'Perdedor Semifinal 1', team2: 'Perdedor Semifinal 2', competition: name, group_name: 'Tercer puesto', series: 'Eliminatorias', tournament: name },
+                        { team1: 'Ganador Semifinal 1', team2: 'Ganador Semifinal 2', competition: name, group_name: 'Final', series: 'Eliminatorias', tournament: name }
+                    ];
+                    await Match.insertMany(elim);
+                } else if (competition.groupsCount > 4) {
+                    const r32Pairs = [
+                        ['A1','B2'], ['C1','D2'], ['E1','F2'], ['G1','H2'],
+                        ['I1','J2'], ['K1','L2'], ['B1','A2'], ['D1','C2'],
+                        ['F1','E2'], ['H1','G2'], ['J1','I2'], ['L1','K2'],
+                        ['A3','C3'], ['E3','G3'], ['I3','K3'], ['B3','D3']
+                    ];
+                    const elim = r32Pairs.map(([t1,t2]) => ({
+                        team1: t1,
+                        team2: t2,
+                        competition: name,
+                        group_name: 'Ronda de 32',
+                        series: 'Eliminatorias',
+                        tournament: name
+                    }));
+                    elim.push(
+                        { team1: 'Ganador R32-1', team2: 'Ganador R32-2', competition: name, group_name: 'Cuartos de final', series: 'Eliminatorias', tournament: name },
+                        { team1: 'Ganador R32-3', team2: 'Ganador R32-4', competition: name, group_name: 'Cuartos de final', series: 'Eliminatorias', tournament: name },
+                        { team1: 'Ganador R32-5', team2: 'Ganador R32-6', competition: name, group_name: 'Cuartos de final', series: 'Eliminatorias', tournament: name },
+                        { team1: 'Ganador R32-7', team2: 'Ganador R32-8', competition: name, group_name: 'Cuartos de final', series: 'Eliminatorias', tournament: name },
+                        { team1: 'Ganador QF1', team2: 'Ganador QF2', competition: name, group_name: 'Semifinal', series: 'Eliminatorias', tournament: name },
+                        { team1: 'Ganador QF3', team2: 'Ganador QF4', competition: name, group_name: 'Semifinal', series: 'Eliminatorias', tournament: name },
+                        { team1: 'Perdedor SF1', team2: 'Perdedor SF2', competition: name, group_name: 'Tercer puesto', series: 'Eliminatorias', tournament: name },
+                        { team1: 'Ganador SF1', team2: 'Ganador SF2', competition: name, group_name: 'Final', series: 'Eliminatorias', tournament: name }
+                    );
+                    await Match.insertMany(elim);
+                }
             }
         }
 

--- a/tests/bracket.update.test.js
+++ b/tests/bracket.update.test.js
@@ -1,10 +1,28 @@
+const request = require('supertest');
+const express = require('express');
 const Match = require('../models/Match');
 const { updateEliminationMatches } = require('../utils/bracket');
 
 jest.mock('../models/Match', () => ({
   find: jest.fn(),
-  updateOne: jest.fn()
+  updateOne: jest.fn(),
+  insertMany: jest.fn()
 }));
+
+jest.mock('../models/Competition', () => {
+  const CompetitionMock = jest.fn(function (data) {
+    Object.assign(this, data);
+    this.save = jest.fn().mockResolvedValue(this);
+  });
+  return CompetitionMock;
+});
+
+jest.mock('../middleware/auth', () => ({
+  isAuthenticated: jest.fn((req, res, next) => next()),
+  isAdmin: jest.fn((req, res, next) => next())
+}));
+
+const adminRouter = require('../routes/admin');
 
 describe('updateEliminationMatches World Cup style', () => {
   afterEach(() => jest.clearAllMocks());
@@ -29,5 +47,44 @@ describe('updateEliminationMatches World Cup style', () => {
       expect.any(Array)
     );
     expect(Match.updateOne).toHaveBeenCalledTimes(24);
+  });
+});
+
+describe('competition creation knockout defaults', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('creates Copa America style matches', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use('/admin', adminRouter);
+
+    const res = await request(app)
+      .post('/admin/competitions')
+      .field('name', 'Copa')
+      .field('groupsCount', '4')
+      .field('integrantsPerGroup', '4');
+
+    expect(res.status).toBe(201);
+    expect(Match.insertMany).toHaveBeenCalledTimes(2);
+    const elim = Match.insertMany.mock.calls[1][0];
+    expect(elim[0]).toHaveProperty('group_name', 'Cuartos de final');
+    expect(elim[elim.length - 1]).toHaveProperty('group_name', 'Final');
+  });
+
+  it('creates World Cup style Round of 32', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use('/admin', adminRouter);
+
+    const res = await request(app)
+      .post('/admin/competitions')
+      .field('name', 'Mundial')
+      .field('groupsCount', '6')
+      .field('integrantsPerGroup', '4');
+
+    expect(res.status).toBe(201);
+    expect(Match.insertMany).toHaveBeenCalledTimes(2);
+    const elim = Match.insertMany.mock.calls[1][0];
+    expect(elim.some(m => m.group_name === 'Ronda de 32')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- insert elimination matches when a competition is created
- generate Round of 32 for World Cup style tournaments
- test automatic knockout generation
- document elimination creation in README

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68798a6ad8948325aca2bd1621124599