### PR TITLE
Send fixture from wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Con esta estructura puedes navegar fácilmente por cada componente de la aplicac
 
 ### Asistente de competencias
 
-Dentro del panel de administración (`/admin/edit`) encontrarás la sección **Competencias**. Haz clic en el botón **Nueva competencia** para abrir el asistente. Allí podrás indicar la cantidad de grupos y equipos por grupo o cargar un archivo de fixture.
+Dentro del panel de administración (`/admin/edit`) encontrarás la sección **Competencias**. Haz clic en el botón **Nueva competencia** para abrir el asistente. Allí podrás indicar la cantidad de grupos y equipos por grupo o cargar un archivo de fixture. El asistente ahora envía la lista de partidos generados al backend, por lo que los nombres de los equipos se guardan automáticamente.
 
 Para replicar el Mundial 2026 utiliza el archivo `worldcup2026_placeholder.json` incluido en la raíz del repositorio al momento de cargar el fixture. Configura además `DEFAULT_COMPETITION=Mundial 2026` en tu archivo `.env` para que la aplicación asigne ese torneo por defecto.
 

--- a/frontend/src/CompetitionWizard.jsx
+++ b/frontend/src/CompetitionWizard.jsx
@@ -52,31 +52,22 @@ export default function CompetitionWizard({ open, onClose, onCreated }) {
   };
 
   const submit = async () => {
-    const data = new FormData();
-    data.append('name', name);
-    data.append('groupsCount', groupsCount);
-    data.append('integrantsPerGroup', teamsPerGroup);
-
     const matches = [];
-      for (let g = 0; g < groupsCount; g++) {
-        const groupName = `Grupo ${letters[g]}`;
-        for (let i = 0; i < teamsPerGroup; i++) {
-          for (let j = i + 1; j < teamsPerGroup; j++) {
-            matches.push({
-              team1: teams[g][i],
-              team2: teams[g][j],
-              competition: name,
-              group_name: groupName,
-              series: 'Fase de grupos',
-              tournament: name
-            });
-          }
+    for (let g = 0; g < groupsCount; g++) {
+      const groupName = `Grupo ${letters[g]}`;
+      for (let i = 0; i < teamsPerGroup; i++) {
+        for (let j = i + 1; j < teamsPerGroup; j++) {
+          matches.push({
+            team1: teams[g][i],
+            team2: teams[g][j],
+            competition: name,
+            group_name: groupName,
+            series: 'Fase de grupos',
+            tournament: name
+          });
         }
       }
-    const blob = new Blob([JSON.stringify(matches)], {
-      type: 'application/json'
-    });
-    data.append('fixture', blob, 'fixture.json');
+    }
     try {
       const res = await fetch('/admin/competitions', {
         method: 'POST',
@@ -84,7 +75,8 @@ export default function CompetitionWizard({ open, onClose, onCreated }) {
         body: JSON.stringify({
           name,
           groupsCount,
-          integrantsPerGroup: teamsPerGroup
+          integrantsPerGroup: teamsPerGroup,
+          fixture: matches
         })
       });
       if (res.ok) {

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -259,7 +259,7 @@ router.delete('/pencas/:id', isAuthenticated, isAdmin, async (req, res) => {
 // Crear competencia
 router.post('/competitions', isAuthenticated, isAdmin, async (req, res) => {
     try {
-        const { name, useApi, groupsCount, integrantsPerGroup } = req.body;
+        const { name, useApi, groupsCount, integrantsPerGroup, fixture } = req.body;
         if (!name) return res.status(400).json({ error: 'Name required' });
 
         const competition = new Competition({
@@ -269,7 +269,13 @@ router.post('/competitions', isAuthenticated, isAdmin, async (req, res) => {
         });
         await competition.save();
 
-        if (String(useApi) === 'true') {
+        if (Array.isArray(fixture) && fixture.length) {
+            const data = fixture.map(m => ({
+                ...m,
+                competition: m.competition || name
+            }));
+            await Match.insertMany(data);
+        } else if (String(useApi) === 'true') {
             const {
                 FOOTBALL_API_KEY,
                 FOOTBALL_LEAGUE_ID,

--- a/tests/admin.test.js
+++ b/tests/admin.test.js
@@ -121,6 +121,29 @@ describe('Admin competition creation', () => {
 
   });
 
+  it('creates a competition with fixture', async () => {
+    Match.insertMany.mockResolvedValue([{ _id: 'm1' }]);
+
+    const app = express();
+    app.use(express.json());
+    app.use('/admin', adminRouter);
+
+    const fixture = [
+      { team1: 'A', team2: 'B', group_name: 'Grupo A', series: 'Fase de grupos', tournament: 'Copa' }
+    ];
+
+    const res = await request(app)
+      .post('/admin/competitions')
+      .send({ name: 'Copa', fixture });
+
+    expect(res.status).toBe(201);
+    expect(Match.insertMany).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ team1: 'A', team2: 'B', competition: 'Copa' })
+      ])
+    );
+  });
+
   it('lists competitions', async () => {
     Competition.find.mockResolvedValue([{ name: 'Copa Test' }]);
 


### PR DESCRIPTION
## Summary
- send generated fixture from the competition wizard to the backend
- handle provided fixture in admin competitions route
- test fixture insertion when creating a competition
- document that the wizard saves team names

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68798a6b1d3883258ee418b1b90a359f