### PR TITLE
Disable default match generation

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -259,7 +259,7 @@ router.delete('/pencas/:id', isAuthenticated, isAdmin, async (req, res) => {
 // Crear competencia
 router.post('/competitions', isAuthenticated, isAdmin, async (req, res) => {
     try {
-        const { name, useApi, groupsCount, integrantsPerGroup, fixture } = req.body;
+        const { name, useApi, groupsCount, integrantsPerGroup, fixture, autoGenerate } = req.body;
         if (!name) return res.status(400).json({ error: 'Name required' });
 
         const competition = new Competition({
@@ -314,7 +314,7 @@ router.post('/competitions', isAuthenticated, isAdmin, async (req, res) => {
             if (matchesData.length) {
                 await Match.insertMany(matchesData);
             }
-        } else if (competition.groupsCount && competition.integrantsPerGroup) {
+        } else if (String(autoGenerate) === 'true' && competition.groupsCount && competition.integrantsPerGroup) {
             const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
             const matches = [];
             for (let g = 0; g < competition.groupsCount; g++) {

--- a/tests/bracket.update.test.js
+++ b/tests/bracket.update.test.js
@@ -62,7 +62,8 @@ describe('competition creation knockout defaults', () => {
       .post('/admin/competitions')
       .field('name', 'Copa')
       .field('groupsCount', '4')
-      .field('integrantsPerGroup', '4');
+      .field('integrantsPerGroup', '4')
+      .field('autoGenerate', 'true');
 
     expect(res.status).toBe(201);
     expect(Match.insertMany).toHaveBeenCalledTimes(2);
@@ -80,7 +81,8 @@ describe('competition creation knockout defaults', () => {
       .post('/admin/competitions')
       .field('name', 'Mundial')
       .field('groupsCount', '6')
-      .field('integrantsPerGroup', '4');
+      .field('integrantsPerGroup', '4')
+      .field('autoGenerate', 'true');
 
     expect(res.status).toBe(201);
     expect(Match.insertMany).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
## Summary
- add `autoGenerate` flag so placeholder matches are only created when requested
- update tests for the new flag

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68798fae08a48325a24f4eefb2eea987