### PR TITLE
Add dynamic elimination bracket generation

### DIFF
--- a/frontend/src/Admin.jsx
+++ b/frontend/src/Admin.jsx
@@ -106,6 +106,7 @@ export default function Admin() {
           name: comp.name,
           groupsCount: comp.groupsCount === '' ? null : Number(comp.groupsCount),
           integrantsPerGroup: comp.integrantsPerGroup === '' ? null : Number(comp.integrantsPerGroup),
+          qualifiersPerGroup: comp.qualifiersPerGroup === '' ? null : Number(comp.qualifiersPerGroup),
         }),
       });
       if (res.ok) loadCompetitions();
@@ -120,6 +121,19 @@ export default function Admin() {
       if (res.ok) loadCompetitions();
     } catch (err) {
       console.error('delete competition error', err);
+    }
+  }
+
+  async function generateBracket(comp) {
+    try {
+      const res = await fetch(`/admin/generate-bracket/${encodeURIComponent(comp.name)}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ qualifiersPerGroup: Number(comp.qualifiersPerGroup || 2) })
+      });
+      if (res.ok) loadCompetitionMatches(comp);
+    } catch (err) {
+      console.error('generate bracket error', err);
     }
   }
 
@@ -296,6 +310,16 @@ export default function Admin() {
                   size="small"
                   sx={{ ml: 1, width: 100 }}
                 />
+                <TextField
+                  type="number"
+                  value={c.qualifiersPerGroup ?? ''}
+                  onChange={e => updateCompetitionField(c._id, 'qualifiersPerGroup', e.target.value)}
+                  size="small"
+                  sx={{ ml: 1, width: 100 }}
+                />
+                <Button variant="outlined" size="small" sx={{ ml: 1 }} onClick={() => generateBracket(c)}>
+                  Generar/Actualizar eliminatorias
+                </Button>
                 <a href="#" className="secondary-content" onClick={e => { e.preventDefault(); saveCompetition(c); }}>💾</a>
                 <a href="#" className="secondary-content red-text" style={{ marginLeft: '1rem' }} onClick={e => { e.preventDefault(); deleteCompetition(c._id); }}>✖</a>
 

--- a/frontend/src/CompetitionWizard.jsx
+++ b/frontend/src/CompetitionWizard.jsx
@@ -8,6 +8,7 @@ export default function CompetitionWizard({ open, onClose, onCreated }) {
   const [name, setName] = useState('');
   const [groupsCount, setGroupsCount] = useState(1);
   const [teamsPerGroup, setTeamsPerGroup] = useState(2);
+  const [qualifiersPerGroup, setQualifiersPerGroup] = useState(2);
   const [teams, setTeams] = useState([]);
 
   useEffect(() => {
@@ -16,6 +17,7 @@ export default function CompetitionWizard({ open, onClose, onCreated }) {
       setName('');
       setGroupsCount(1);
       setTeamsPerGroup(2);
+      setQualifiersPerGroup(2);
       setTeams([]);
     }
   }, [open]);
@@ -76,6 +78,7 @@ export default function CompetitionWizard({ open, onClose, onCreated }) {
           name,
           groupsCount,
           integrantsPerGroup: teamsPerGroup,
+          qualifiersPerGroup,
           fixture: matches
         })
       });
@@ -116,6 +119,14 @@ export default function CompetitionWizard({ open, onClose, onCreated }) {
               placeholder="Integrantes"
               style={{ marginLeft: '10px', width: '100px' }}
               min={2}
+            />
+            <input
+              type="number"
+              value={qualifiersPerGroup}
+              onChange={e => setQualifiersPerGroup(Number(e.target.value))}
+              placeholder="Clasificados"
+              style={{ marginLeft: '10px', width: '100px' }}
+              min={1}
             />
 
           </div>

--- a/models/Competition.js
+++ b/models/Competition.js
@@ -3,7 +3,8 @@ const mongoose = require('mongoose');
 const competitionSchema = new mongoose.Schema({
     name: { type: String, unique: true, required: true },
     groupsCount: Number,
-    integrantsPerGroup: Number
+    integrantsPerGroup: Number,
+    qualifiersPerGroup: Number
 });
 
 module.exports = mongoose.models.Competition || mongoose.model('Competition', competitionSchema);

--- a/tests/bracket.generate.test.js
+++ b/tests/bracket.generate.test.js
@@ -1,0 +1,32 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../utils/bracket', () => ({
+  updateEliminationMatches: jest.fn(),
+  generateEliminationBracket: jest.fn()
+}));
+
+jest.mock('../middleware/auth', () => ({
+  isAuthenticated: jest.fn((req, res, next) => next()),
+  isAdmin: jest.fn((req, res, next) => next())
+}));
+
+const { generateEliminationBracket } = require('../utils/bracket');
+const adminRouter = require('../routes/admin');
+
+describe('generate bracket route', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('triggers bracket generation', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use('/admin', adminRouter);
+
+    const res = await request(app)
+      .post('/admin/generate-bracket/Copa')
+      .send({ qualifiersPerGroup: 2 });
+
+    expect(res.status).toBe(200);
+    expect(generateEliminationBracket).toHaveBeenCalledWith('Copa', 2);
+  });
+});


### PR DESCRIPTION
## Summary
- add qualifiersPerGroup field for competitions
- generate brackets dynamically via `generateEliminationBracket`
- expose new admin route to generate brackets
- allow admins to set qualifiers per group and trigger generation from UI
- add wizard option and route test for the new feature

## Testing
- `npm ci` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879a288aa348325aa23f1d113fe7efb