### PR TITLE
Add knockout match ordering support

### DIFF
--- a/frontend/src/Admin.jsx
+++ b/frontend/src/Admin.jsx
@@ -69,6 +69,9 @@ export default function Admin() {
       const res = await fetch(`/admin/competitions/${encodeURIComponent(comp.name)}/matches`);
       if (!res.ok) return;
       const data = await res.json();
+      data.forEach((m, i) => {
+        if (m.order === undefined || m.order === null) m.order = i;
+      });
       setMatchesByCompetition(ms => ({ ...ms, [comp._id]: data }));
       if (data.length) {
         await loadGroups([comp.name]);
@@ -252,6 +255,40 @@ export default function Admin() {
     }
   }
 
+  function moveMatch(compId, round, id, dir) {
+    setMatchesByCompetition(ms => {
+      const arr = ms[compId].map(m => ({ ...m }));
+      const roundMs = arr.filter(m => (m.group_name || 'Otros') === round);
+      roundMs.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+      const idx = roundMs.findIndex(m => m._id === id);
+      const target = roundMs[idx + dir];
+      if (!target) return ms;
+      const current = roundMs[idx];
+      const tmp = current.order ?? idx;
+      current.order = target.order ?? (idx + dir);
+      target.order = tmp;
+      const update = new Map(roundMs.map(m => [m._id, m]));
+      const result = arr.map(m => update.get(m._id) || m);
+      return { ...ms, [compId]: result };
+    });
+  }
+
+  async function saveOrder(comp, round) {
+    const list = (matchesByCompetition[comp._id] || [])
+      .filter(m => (m.group_name || 'Otros') === round)
+      .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+      .map(m => m._id);
+    try {
+      await fetch(`/admin/competitions/${encodeURIComponent(comp.name)}/knockout-order`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ order: list })
+      });
+    } catch (err) {
+      console.error('save order error', err);
+    }
+  }
+
   return (
     <div className="container" style={{ marginTop: '2rem' }}>
       <h5>Administración</h5>
@@ -319,7 +356,7 @@ export default function Admin() {
                     </AccordionSummary>
                     <AccordionDetails>
                       <ul className="collection">
-                        {ms.map(m => (
+                        {ms.map((m, idx) => (
                           <li key={m._id} className="collection-item">
                             <TextField
                               value={m.team1 || ''}
@@ -360,10 +397,17 @@ export default function Admin() {
                               size="small"
                               sx={{ ml: 1, width: 60 }}
                             />
-                            <a href="#" className="secondary-content" onClick={e => { e.preventDefault(); saveMatch(c._id, m); }}>💾</a>
+                            <span className="secondary-content">
+                              <a href="#" onClick={e => { e.preventDefault(); moveMatch(c._id, round, m._id, -1); }}>▲</a>
+                              <a href="#" style={{ marginLeft: '0.5rem' }} onClick={e => { e.preventDefault(); moveMatch(c._id, round, m._id, 1); }}>▼</a>
+                              <a href="#" style={{ marginLeft: '0.5rem' }} onClick={e => { e.preventDefault(); saveMatch(c._id, m); }}>💾</a>
+                            </span>
                           </li>
                         ))}
                       </ul>
+                      <Button size="small" variant="outlined" sx={{ mt: 1 }} onClick={() => saveOrder(c, round)}>
+                        Guardar orden
+                      </Button>
                       {groups[c.name]?.filter(gr => gr.group === round).length ? (
                         <GroupTable groups={groups[c.name].filter(gr => gr.group === round)} />
                       ) : null}

--- a/models/Match.js
+++ b/models/Match.js
@@ -10,7 +10,8 @@ const matchSchema = new mongoose.Schema({
     series: String,
     tournament: String,
     result1: Number,
-    result2: Number
+    result2: Number,
+    order: Number
 });
  
 module.exports = mongoose.models.Match || mongoose.model('Match', matchSchema);

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -441,6 +441,23 @@ router.get('/competitions/:id/matches', isAuthenticated, isAdmin, async (req, re
     }
 });
 
+// Actualizar orden de partidos knockout
+router.put('/competitions/:id/knockout-order', isAuthenticated, isAdmin, async (req, res) => {
+    try {
+        const { order } = req.body;
+        if (!Array.isArray(order)) {
+            return res.status(400).json({ error: 'order array required' });
+        }
+        await Promise.all(order.map((id, idx) =>
+            Match.updateOne({ _id: id, competition: req.params.id }, { order: idx })
+        ));
+        res.json({ message: 'Order updated' });
+    } catch (error) {
+        console.error('Error updating match order:', error);
+        res.status(500).json({ error: 'Internal server error' });
+    }
+});
+
 // Actualizar datos de un partido
 router.put('/competitions/:id/matches/:matchId', isAuthenticated, isAdmin, async (req, res) => {
     try {

--- a/routes/bracket.js
+++ b/routes/bracket.js
@@ -22,7 +22,10 @@ router.get('/:competition', async (req, res) => {
       bracket[round].push(m);
     }
     Object.values(bracket).forEach(arr =>
-      arr.sort((a, b) => new Date(`${a.date}T${a.time}`) - new Date(`${b.date}T${b.time}`))
+      arr.sort((a, b) => {
+        if (a.order != null && b.order != null) return a.order - b.order;
+        return new Date(`${a.date}T${a.time}`) - new Date(`${b.date}T${b.time}`);
+      })
     );
     res.json(bracket);
   } catch (err) {

--- a/tests/admin.matches.test.js
+++ b/tests/admin.matches.test.js
@@ -3,7 +3,8 @@ const express = require('express');
 
 jest.mock('../models/Match', () => ({
   find: jest.fn(),
-  findById: jest.fn()
+  findById: jest.fn(),
+  updateOne: jest.fn()
 }));
 
 jest.mock('../utils/bracket', () => ({
@@ -68,5 +69,19 @@ describe('Admin match management', () => {
     expect(match.result1).toBe(2);
     expect(match.result2).toBe(1);
     expect(updateEliminationMatches).toHaveBeenCalledWith('c1');
+  });
+
+  it('updates knockout match order', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use('/admin', adminRouter);
+
+    const res = await request(app)
+      .put('/admin/competitions/c1/knockout-order')
+      .send({ order: ['m1', 'm2'] });
+
+    expect(res.status).toBe(200);
+    expect(Match.updateOne).toHaveBeenCalledWith({ _id: 'm1', competition: 'c1' }, { order: 0 });
+    expect(Match.updateOne).toHaveBeenCalledWith({ _id: 'm2', competition: 'c1' }, { order: 1 });
   });
 });


### PR DESCRIPTION
## Summary
- allow sorting knockout matches via new `order` field
- expose `/admin/competitions/:id/knockout-order` for saving ordering
- sort bracket endpoint using stored order
- add move buttons in admin panel to reorder and persist knockout matches
- test new route

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879a288ea448325bbab51c16481601f