### PR TITLE
Add MUI icons package

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,8 @@
     "@mui/material": "^5.15.14",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "@g-loot/react-tournament-brackets": "^1.0.4"
+    "@g-loot/react-tournament-brackets": "^1.0.4",
+    "@mui/icons-material": "^5.15.14"
 
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add `@mui/icons-material` to frontend dependencies

## Testing
- `npm run vercel-build` *(fails: 403 Forbidden from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6879bccb0b408325b44050852041ce33