### PR TITLE
Ensure saveRound recalculates bracket

### DIFF
--- a/frontend/src/Admin.jsx
+++ b/frontend/src/Admin.jsx
@@ -296,7 +296,14 @@ export default function Admin() {
     );
     await Promise.all(matches.map(m => saveMatch(compId, m, true)));
     if (matches.length) {
-      loadCompetitionMatches({ _id: compId, name: matches[0].competition });
+      const compName = matches[0].competition;
+      const res = await fetch(
+        `/admin/recalculate-bracket/${encodeURIComponent(compName)}`,
+        { method: 'POST' }
+      );
+      if (res.ok) {
+        loadCompetitionMatches({ _id: compId, name: compName });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure saveRound sends POST to recalculate bracket and waits for response

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879c24c8a508325be113a5ccae4e345