### PR TITLE
Fix Admin import list

### DIFF
--- a/frontend/src/Admin.jsx
+++ b/frontend/src/Admin.jsx
@@ -12,7 +12,9 @@ import {
   Typography,
   Checkbox,
   FormControlLabel,
-  IconButton
+  IconButton,
+  Snackbar,
+  Alert
 } from '@mui/material';
 import Save from '@mui/icons-material/Save';
 import GroupTable from './GroupTable';


### PR DESCRIPTION
## Summary
- fix MUI import list in Admin page

## Testing
- `npm run build --prefix frontend` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a53fa495883259705cbbe0d240311