### PR TITLE
Add optional rules and prizes fields to Penca model

### DIFF
--- a/models/Penca.js
+++ b/models/Penca.js
@@ -7,6 +7,8 @@ const pencaSchema = new mongoose.Schema({
   competition: { type: String, required: true },
   participantLimit: { type: Number, default: 20 },
   isPublic: { type: Boolean, default: false },
+  rules: { type: String },
+  prizes: { type: String },
   fixture: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Match' }],
   participants: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
   pendingRequests: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }]


### PR DESCRIPTION
## Summary
- extend `Penca` schema with optional string fields `rules` and `prizes`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a7f3686e083259c1d04e721a82f59