### PR TITLE
Add editing for rules/prizes

### DIFF
--- a/frontend/src/OwnerPanel.jsx
+++ b/frontend/src/OwnerPanel.jsx
@@ -1,5 +1,12 @@
 import { useEffect, useState } from 'react';
-import { Card, CardContent, Checkbox, FormControlLabel, Button } from '@mui/material';
+import {
+  Card,
+  CardContent,
+  Checkbox,
+  FormControlLabel,
+  Button,
+  TextField
+} from '@mui/material';
 
 export default function OwnerPanel() {
   const [pencas, setPencas] = useState([]);
@@ -70,6 +77,25 @@ export default function OwnerPanel() {
       if (res.ok) loadData();
     } catch (err) {
       console.error('remove participant error', err);
+    }
+  }
+
+  const updateField = (id, field, value) => {
+    setPencas(ps => ps.map(p => p._id === id ? { ...p, [field]: value } : p));
+  };
+
+  async function saveInfo(id) {
+    const penca = pencas.find(p => p._id === id);
+    if (!penca) return;
+    try {
+      const res = await fetch(`/pencas/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rules: penca.rules, prizes: penca.prizes })
+      });
+      if (res.ok) loadData();
+    } catch (err) {
+      console.error('save info error', err);
     }
   }
 
@@ -185,6 +211,33 @@ export default function OwnerPanel() {
                     ))}
                   </div>
                 ))}
+
+              <TextField
+                label="Reglamento"
+                value={p.rules || ''}
+                onChange={e => updateField(p._id, 'rules', e.target.value)}
+                multiline
+                fullWidth
+                size="small"
+                sx={{ mt: 1 }}
+              />
+              <TextField
+                label="Premios"
+                value={p.prizes || ''}
+                onChange={e => updateField(p._id, 'prizes', e.target.value)}
+                multiline
+                fullWidth
+                size="small"
+                sx={{ mt: 1 }}
+              />
+              <Button
+                size="small"
+                variant="contained"
+                sx={{ mt: 1 }}
+                onClick={() => saveInfo(p._id)}
+              >
+                Guardar
+              </Button>
               <h6>Solicitudes</h6>
               <ul className="collection">
                 {p.pendingRequests.map(u => (

--- a/main.js
+++ b/main.js
@@ -206,7 +206,7 @@ app.get('/api/owner', isAuthenticated, async (req, res) => {
     }
     try {
         const pencas = await Penca.find({ owner: user._id })
-            .select('name code competition participants pendingRequests')
+            .select('name code competition participants pendingRequests rules prizes isPublic fixture')
             .populate('participants', 'username')
             .populate('pendingRequests', 'username');
         res.json({ user: { username: user.username, role: user.role }, pencas });

--- a/routes/penca.js
+++ b/routes/penca.js
@@ -28,7 +28,7 @@ router.get('/mine', isAuthenticated, async (req, res) => {
     }
 
     const pencas = await Penca.find(filter)
-      .select('name code competition participants pendingRequests')
+      .select('name code competition participants pendingRequests rules prizes isPublic fixture')
       .populate('pendingRequests', 'username')
       .populate('participants', 'username');
 
@@ -88,7 +88,7 @@ router.get('/:pencaId', isAuthenticated, async (req, res) => {
 // Actualizar una penca (owner)
 router.put('/:pencaId', isAuthenticated, async (req, res) => {
   const { pencaId } = req.params;
-  const { isPublic } = req.body;
+  const { isPublic, rules, prizes } = req.body;
   try {
     const penca = await Penca.findById(pencaId);
     if (!penca) return res.status(404).json({ error: 'Penca not found' });
@@ -96,6 +96,8 @@ router.put('/:pencaId', isAuthenticated, async (req, res) => {
       return res.status(403).json({ error: 'Forbidden' });
     }
     if (isPublic !== undefined) penca.isPublic = isPublic === true || isPublic === 'true';
+    if (rules !== undefined) penca.rules = rules;
+    if (prizes !== undefined) penca.prizes = prizes;
     await penca.save();
     res.json({ message: 'Penca updated' });
   } catch (err) {

--- a/tests/penca.test.js
+++ b/tests/penca.test.js
@@ -147,3 +147,32 @@ describe('Penca listing includes code', () => {
     expect(res.body[0]).toHaveProperty('code', 'EFGH');
   });
 });
+
+describe('Penca rules and prizes update', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('updates rules and prizes', async () => {
+    const penca = {
+      _id: 'p1',
+      owner: 'o1',
+      save: jest.fn().mockResolvedValue(true)
+    };
+    Penca.findById = jest.fn().mockResolvedValue(penca);
+
+    const app = express();
+    app.use(express.json());
+    app.use((req, res, next) => { req.session = { user: { _id: 'o1' } }; next(); });
+    app.use('/pencas', pencaRouter);
+
+    const res = await request(app)
+      .put('/pencas/p1')
+      .send({ rules: 'new', prizes: 'prize' });
+
+    expect(res.status).toBe(200);
+    expect(penca.rules).toBe('new');
+    expect(penca.prizes).toBe('prize');
+    expect(penca.save).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- let owners update `rules` and `prizes` via PUT `/pencas/:pencaId`
- expose `rules` and `prizes` in owner APIs
- show editable fields for `rules` and `prizes` in owner panel
- test updating these new fields

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` in frontend *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a8d6617b48325ac354c72eecf3010