### PR TITLE
Show rules and prizes info in dashboard

### DIFF
--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -1,7 +1,19 @@
 import { useEffect, useState } from 'react';
 import GroupTable from './GroupTable';
 import EliminationBracket from './EliminationBracket';
-import { Button, Card, CardContent, TextField } from '@mui/material';
+import {
+  Button,
+  Card,
+  CardContent,
+  TextField,
+  IconButton,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Typography
+} from '@mui/material';
+import InfoOutlined from '@mui/icons-material/InfoOutlined';
 import MUIBracket from './MUIBracket';
 import roundOrder from './roundOrder';
 
@@ -18,6 +30,7 @@ export default function Dashboard() {
   const [ownerPencas, setOwnerPencas] = useState([]);
   const [groups, setGroups] = useState({});
   const [bracket, setBracket] = useState(null);
+  const [infoPenca, setInfoPenca] = useState(null);
 
   useEffect(() => {
     async function load() {
@@ -203,7 +216,18 @@ export default function Dashboard() {
               onClick={() => setOpen(open === p._id ? null : p._id)}
             >
               <CardContent>
-                <strong>{p.name}</strong>
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                  <strong>{p.name}</strong>
+                  <IconButton
+                    size="small"
+                    onClick={e => {
+                      e.stopPropagation();
+                      setInfoPenca(p);
+                    }}
+                  >
+                    <InfoOutlined fontSize="small" />
+                  </IconButton>
+                </div>
               </CardContent>
             </Card>
             {open === p._id && (
@@ -395,6 +419,27 @@ export default function Dashboard() {
           </ul>
         </div>
       ))}
+
+      <Dialog open={!!infoPenca} onClose={() => setInfoPenca(null)}>
+        <DialogTitle>{infoPenca?.name}</DialogTitle>
+        <DialogContent dividers>
+          <Typography variant="subtitle2" gutterBottom>
+            Reglas
+          </Typography>
+          <Typography variant="body2" paragraph>
+            {infoPenca?.rules || 'Sin reglas definidas'}
+          </Typography>
+          <Typography variant="subtitle2" gutterBottom>
+            Premios
+          </Typography>
+          <Typography variant="body2">
+            {infoPenca?.prizes || 'Sin premios definidos'}
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setInfoPenca(null)}>Cerrar</Button>
+        </DialogActions>
+      </Dialog>
     </div>
   );
 }

--- a/main.js
+++ b/main.js
@@ -191,7 +191,7 @@ app.get('/api/dashboard', isAuthenticated, async (req, res) => {
         return res.status(403).json({ error: 'Admins must use /admin/edit' });
     }
     try {
-        const pencas = await Penca.find({ participants: user._id }).select('name _id competition fixture');
+        const pencas = await Penca.find({ participants: user._id }).select('name _id competition fixture rules prizes');
         res.json({ user: { username: user.username, role: user.role }, pencas });
     } catch (err) {
         console.error('dashboard api error', err);


### PR DESCRIPTION
## Summary
- include `rules` and `prizes` fields in the `/api/dashboard` endpoint
- add an info button for each penca card
- show rules and prizes inside a dialog

## Testing
- `npm run build --prefix frontend` *(fails: vite not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a900e5cbc83258566ddc38bb7bdcc