### PR TITLE
Fix MUIBracket startTime and remove theme

### DIFF
--- a/frontend/src/MUIBracket.jsx
+++ b/frontend/src/MUIBracket.jsx
@@ -17,7 +17,7 @@ export default function MUIBracket({ bracket }) {
           name: round,
           nextMatchId: null,
           tournamentRoundText: round,
-          startTime: new Date(`${m.date}T${m.time}`),
+          startTime: `${m.date}T${m.time}`,
           state: 'SCHEDULED',
           participants: [
             { id: m.team1, name: m.team1 },
@@ -31,12 +31,6 @@ export default function MUIBracket({ bracket }) {
 
   if (!matches.length) return null;
 
-  const theme = {
-    textColor: '#212121',
-    matchBackground: '#fafafa',
-    score: { background: '#1976d2' }
-  };
-
   return (
     <Box sx={{ mt: 3 }}>
       <Typography variant="h6" gutterBottom>Bracket Prototype</Typography>
@@ -44,7 +38,6 @@ export default function MUIBracket({ bracket }) {
         <SingleEliminationBracket
           matchComponent={Match}
           matches={matches}
-          theme={theme}
         />
       </Paper>
     </Box>


### PR DESCRIPTION
## Summary
- remove custom theme from bracket component so defaults are used
- pass match time as a string instead of Date

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a95916a80832592449fa69e63f3d0