### PR TITLE
Validate non-negative predictions

### DIFF
--- a/frontend/src/Admin.jsx
+++ b/frontend/src/Admin.jsx
@@ -446,6 +446,7 @@ export default function Admin() {
                               onChange={e => updateMatchField(c._id, m._id, 'result1', e.target.value)}
                               size="small"
                               sx={{ ml: 1, width: 60 }}
+                              inputProps={{ min: 0 }}
                             />
                             <TextField
                               type="number"
@@ -453,6 +454,7 @@ export default function Admin() {
                               onChange={e => updateMatchField(c._id, m._id, 'result2', e.target.value)}
                               size="small"
                               sx={{ ml: 1, width: 60 }}
+                              inputProps={{ min: 0 }}
                             />
                             <span className="secondary-content">
                               <IconButton size="small" onClick={() => saveMatch(c._id, m)} disabled={isSaving}>

--- a/frontend/src/PencaSection.jsx
+++ b/frontend/src/PencaSection.jsx
@@ -103,6 +103,7 @@ export default function PencaSection({ penca, matches, groups, getPrediction, ha
                                   required
                                   size="small"
                                   sx={{ width: 60 }}
+                                  inputProps={{ min: 0 }}
                                   disabled={!editable}
                                 />
                                 <span>-</span>
@@ -113,6 +114,7 @@ export default function PencaSection({ penca, matches, groups, getPrediction, ha
                                   required
                                   size="small"
                                   sx={{ width: 60, ml: 1 }}
+                                  inputProps={{ min: 0 }}
                                   disabled={!editable}
                                 />
                               </div>
@@ -167,6 +169,7 @@ export default function PencaSection({ penca, matches, groups, getPrediction, ha
                                       required
                                       size="small"
                                       sx={{ width: 60 }}
+                                      inputProps={{ min: 0 }}
                                       disabled={!editable}
                                     />
                                     <span>-</span>
@@ -177,6 +180,7 @@ export default function PencaSection({ penca, matches, groups, getPrediction, ha
                                       required
                                       size="small"
                                       sx={{ width: 60, ml: 1 }}
+                                      inputProps={{ min: 0 }}
                                       disabled={!editable}
                                     />
                                   </div>

--- a/models/Prediction.js
+++ b/models/Prediction.js
@@ -5,8 +5,8 @@ const predictionSchema = new mongoose.Schema({
     username: { type: String, required: true },
     matchId: { type: mongoose.Schema.Types.ObjectId, required: true },
     pencaId: { type: mongoose.Schema.Types.ObjectId, ref: 'Penca', required: true },
-    result1: { type: Number, required: true },
-    result2: { type: Number, required: true },
+    result1: { type: Number, required: true, min: 0 },
+    result2: { type: Number, required: true, min: 0 },
 });
 
 predictionSchema.index({ userId: 1, matchId: 1, pencaId: 1 }, { unique: true });

--- a/routes/predictions.js
+++ b/routes/predictions.js
@@ -23,6 +23,14 @@ router.get('/', async (req, res) => {
 router.post('/', async (req, res) => {
     try {
         const { matchId, result1, result2, pencaId } = req.body;
+        const r1 = Number(result1);
+        const r2 = Number(result2);
+        if (Number.isNaN(r1) || Number.isNaN(r2)) {
+            return res.status(400).json({ error: 'Resultados inválidos' });
+        }
+        if (r1 < 0 || r2 < 0) {
+            return res.status(400).json({ error: 'Los goles no pueden ser negativos' });
+        }
         const user = req.session.user;
         if (!user) {
             return res.status(401).json({ error: 'No autorizado' });
@@ -60,15 +68,15 @@ router.post('/', async (req, res) => {
 
         let prediction = await Prediction.findOne({ userId: user._id, matchId, pencaId });
         if (prediction) {
-            prediction.result1 = result1;
-            prediction.result2 = result2;
+            prediction.result1 = r1;
+            prediction.result2 = r2;
         } else {
             prediction = new Prediction({
                 userId: user._id,
                 matchId,
                 pencaId,
-                result1,
-                result2,
+                result1: r1,
+                result2: r2,
                 username: user.username
             });
         }

--- a/tests/predictions.test.js
+++ b/tests/predictions.test.js
@@ -61,4 +61,21 @@ describe('Predictions Routes', () => {
 
     expect(res.status).toBe(400);
   });
+
+  it('rejects prediction with negative scores', async () => {
+    Prediction.findOne.mockResolvedValue(null);
+    const futureDate = new Date(Date.now() + 3600 * 1000).toISOString().split('T')[0];
+    Match.findById.mockResolvedValue({ date: futureDate, time: '23:59' });
+
+    const app = express();
+    app.use(express.json());
+    app.use((req, res, next) => { req.session = { user: { _id: 'u1', username: 'tester' } }; next(); });
+    app.use('/predictions', predictionsRouter);
+
+    const res = await request(app)
+      .post('/predictions')
+      .send({ matchId: 'm1', result1: -1, result2: 0 });
+
+    expect(res.status).toBe(400);
+  });
 });


### PR DESCRIPTION
## Summary
- enforce non-negative numbers in prediction schema
- validate numbers in `/predictions` route
- block negative values in admin and user forms
- test that negative scores are rejected

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aa1cd28088325ae1a695036971a8e