### PR TITLE
Add register link on login page

### DIFF
--- a/frontend/src/Login.jsx
+++ b/frontend/src/Login.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import {
   Button,
   Card,
@@ -74,6 +74,15 @@ export default function Login() {
             Ingresar
           </Button>
         </form>
+        <Button
+          component={Link}
+          to="/register"
+          variant="outlined"
+          fullWidth
+          style={{ marginTop: '1rem' }}
+        >
+          Registrarse
+        </Button>
         {error && (
           <div className="red-text" style={{ marginTop: '1rem' }}>{error}</div>
         )}


### PR DESCRIPTION
## Summary
- add react-router `Link` import
- add `Registrarse` link after login button in `Login.jsx`

## Testing
- `npm test` *(fails: jest not found)*
- `cd frontend && npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d8e0e41888325923b477a2da86e2a