### PR TITLE
Fix ranking user filter

### DIFF
--- a/routes/ranking.js
+++ b/routes/ranking.js
@@ -9,7 +9,9 @@ const { DEFAULT_COMPETITION } = require('../config');
 
 // Función para calcular los puntajes
 async function calculateScores(pencaId, competition) {
-    let userFilter = { valid: true };
+    // Solo filtramos por participantes de la penca cuando sea necesario
+    // No requerimos que los usuarios sean válidos aquí
+    let userFilter = {};
     let matchFilter = {};
     let predictionFilter = {};
     let penca;


### PR DESCRIPTION
## Summary
- avoid filtering scores by the `valid` field so that only penca membership is checked

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d92454640832589b5740155e89e63