### PR TITLE
Add language middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ PORT=3000
 MAX_PENCAS_PER_USER=3
 # Idioma de los mensajes (es o en)
 APP_LANG=es
+Tambin puedes cambiar el idioma de las respuestas agregando `?lang=es` o `?lang=en` a cada solicitud, o enviando el encabezado `Accept-Language`.
 # Credenciales para obtener fixtures desde API-Football
 FOOTBALL_API_KEY=<tu_api_key>
 # Identificador de liga y temporada
@@ -45,6 +46,7 @@ El valor `MAX_PENCAS_PER_USER` controla cuántas pencas puede integrar cada usua
 útil si planeas varias competiciones en paralelo.
 
 `APP_LANG` permite elegir el idioma de las respuestas del backend. Usa `es` para español o `en` para inglés.
+Tambin puedes cambiar el idioma de las respuestas agregando `?lang=es` o `?lang=en` a cada solicitud, o enviando el encabezado `Accept-Language`.
 
 La variable `DEFAULT_COMPETITION` define el nombre de la competencia principal.
 Debes crearla desde el asistente de competencias en el panel de administración

--- a/middleware/language.js
+++ b/middleware/language.js
@@ -1,0 +1,20 @@
+const { translations } = require('../utils/messages');
+
+function language(req, res, next) {
+  let lang = req.query.lang;
+  if (!lang) {
+    const header = req.headers['accept-language'];
+    if (header) {
+      lang = header.split(',')[0].trim();
+      const sepIndex = lang.indexOf('-');
+      if (sepIndex !== -1) lang = lang.slice(0, sepIndex);
+    }
+  }
+  if (!translations[lang]) {
+    lang = undefined;
+  }
+  req.lang = lang;
+  next();
+}
+
+module.exports = language;

--- a/routes/predictions.js
+++ b/routes/predictions.js
@@ -17,7 +17,7 @@ router.get('/', async (req, res) => {
         const predictions = await Prediction.find();
         res.json(predictions);
     } catch (err) {
-        res.status(500).json({ error: getMessage('PREDICTIONS_FETCH_ERROR') });
+        res.status(500).json({ error: getMessage('PREDICTIONS_FETCH_ERROR', req.lang) });
     }
 });
 
@@ -27,29 +27,29 @@ router.post('/', async (req, res) => {
         const r1 = Number(result1);
         const r2 = Number(result2);
         if (Number.isNaN(r1) || Number.isNaN(r2)) {
-            return res.status(400).json({ error: getMessage('INVALID_RESULTS') });
+            return res.status(400).json({ error: getMessage('INVALID_RESULTS', req.lang) });
         }
         if (r1 < 0 || r2 < 0) {
-            return res.status(400).json({ error: getMessage('NEGATIVE_GOALS') });
+            return res.status(400).json({ error: getMessage('NEGATIVE_GOALS', req.lang) });
         }
         const user = req.session.user;
         if (!user) {
-            return res.status(401).json({ error: getMessage('UNAUTHORIZED') });
+            return res.status(401).json({ error: getMessage('UNAUTHORIZED', req.lang) });
         }
 
         if (!pencaId) {
-            return res.status(400).json({ error: getMessage('PENCA_ID_REQUIRED') });
+            return res.status(400).json({ error: getMessage('PENCA_ID_REQUIRED', req.lang) });
         }
 
         const penca = await Penca.findById(pencaId);
         if (!penca || !penca.participants.some(id => id.equals(user._id))) {
-            return res.status(403).json({ error: getMessage('NOT_IN_PENCA') });
+            return res.status(403).json({ error: getMessage('NOT_IN_PENCA', req.lang) });
         }
 
         // Obtener información del partido
         const match = await Match.findById(matchId);
         if (!match) {
-            return res.status(404).json({ error: getMessage('MATCH_NOT_FOUND') });
+            return res.status(404).json({ error: getMessage('MATCH_NOT_FOUND', req.lang) });
         }
 
         // Verificar si falta menos de media hora para el partido
@@ -64,7 +64,7 @@ router.post('/', async (req, res) => {
         debugLog(`timeDifference: ${timeDifference} minutos`);
 
         if (timeDifference < 30) {
-            return res.status(400).json({ error: getMessage('PREDICTION_TIME') });
+            return res.status(400).json({ error: getMessage('PREDICTION_TIME', req.lang) });
         }
 
         let prediction = await Prediction.findOne({ userId: user._id, matchId, pencaId });
@@ -82,10 +82,10 @@ router.post('/', async (req, res) => {
             });
         }
         await prediction.save();
-        res.json({ message: getMessage('PREDICTION_SAVED') });
+        res.json({ message: getMessage('PREDICTION_SAVED', req.lang) });
     } catch (err) {
         console.error('Error al guardar la predicción:', err);
-        res.status(500).json({ error: getMessage('PREDICTION_SAVE_ERROR') });
+        res.status(500).json({ error: getMessage('PREDICTION_SAVE_ERROR', req.lang) });
     }
 });
 

--- a/routes/ranking.js
+++ b/routes/ranking.js
@@ -101,7 +101,7 @@ router.get('/', async (req, res) => {
         res.json(scores);
     } catch (err) {
         console.error('Error al obtener el ranking:', err);
-        res.status(500).json({ error: getMessage('RANKING_ERROR') });
+        res.status(500).json({ error: getMessage('RANKING_ERROR', req.lang) });
     }
 });
 
@@ -112,7 +112,7 @@ router.get('/competition/:competition', async (req, res) => {
         res.json(scores);
     } catch (err) {
         console.error('Error al obtener el ranking por competencia:', err);
-        res.status(500).json({ error: getMessage('RANKING_ERROR') });
+        res.status(500).json({ error: getMessage('RANKING_ERROR', req.lang) });
     }
 });
 
@@ -129,10 +129,10 @@ router.post('/recalculate', async (req, res) => {
                 { upsert: true }
             );
         }
-        res.json({ message: getMessage('SCORES_RECALCULATED') });
+        res.json({ message: getMessage('SCORES_RECALCULATED', req.lang) });
     } catch (err) {
         console.error('Error al recalcular los puntajes:', err);
-        res.status(500).json({ error: getMessage('SCORES_RECALC_ERROR') });
+        res.status(500).json({ error: getMessage('SCORES_RECALC_ERROR', req.lang) });
     }
 });
 


### PR DESCRIPTION
## Summary
- add language middleware parsing `lang` param or `Accept-Language` header
- pass the language code to `getMessage()` in backend responses
- document how to override message language

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687da066e678832580d82293ef186f10