### PR TITLE
Update defaultValue checks in PencaSection

### DIFF
--- a/frontend/src/PencaSection.jsx
+++ b/frontend/src/PencaSection.jsx
@@ -117,7 +117,7 @@ export default function PencaSection({ penca, matches, groups, getPrediction, ha
                                     <TextField
                                       name="result1"
                                       type="number"
-                                      defaultValue={pr.result1 || ''}
+                                      defaultValue={pr.result1 ?? ''}
                                       required
                                       size="small"
                                       sx={{ width: 60 }}
@@ -128,7 +128,7 @@ export default function PencaSection({ penca, matches, groups, getPrediction, ha
                                     <TextField
                                       name="result2"
                                       type="number"
-                                      defaultValue={pr.result2 || ''}
+                                      defaultValue={pr.result2 ?? ''}
                                       required
                                       size="small"
                                       sx={{ width: 60, ml: 1 }}
@@ -177,7 +177,7 @@ export default function PencaSection({ penca, matches, groups, getPrediction, ha
                                         <TextField
                                           name="result1"
                                           type="number"
-                                          defaultValue={pr.result1 || ''}
+                                          defaultValue={pr.result1 ?? ''}
                                           required
                                           size="small"
                                           sx={{ width: 60 }}
@@ -188,7 +188,7 @@ export default function PencaSection({ penca, matches, groups, getPrediction, ha
                                         <TextField
                                           name="result2"
                                           type="number"
-                                          defaultValue={pr.result2 || ''}
+                                          defaultValue={pr.result2 ?? ''}
                                           required
                                           size="small"
                                           sx={{ width: 60, ml: 1 }}


### PR DESCRIPTION
## Summary
- use nullish coalescing when populating prediction defaults

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e430e21f083259364ec9deef95873