### PR TITLE
Fix dashboard scoring return

### DIFF
--- a/main.js
+++ b/main.js
@@ -194,7 +194,7 @@ app.get('/api/dashboard', isAuthenticated, async (req, res) => {
         return res.status(403).json({ error: getMessage('ADMIN_ONLY', req.lang) });
     }
     try {
-        const pencas = await Penca.find({ participants: user._id }).select('name _id competition fixture rules prizes');
+        const pencas = await Penca.find({ participants: user._id }).select('name _id competition fixture rules prizes scoring');
         res.json({ user: { username: user.username, role: user.role }, pencas });
     } catch (err) {
         console.error('dashboard api error', err);

--- a/tests/dashboard.api.test.js
+++ b/tests/dashboard.api.test.js
@@ -1,0 +1,43 @@
+const request = require('supertest');
+const express = require('express');
+const session = require('express-session');
+
+jest.mock('../models/Penca', () => ({ find: jest.fn() }));
+jest.mock('../middleware/auth', () => ({ isAuthenticated: jest.fn((req, res, next) => next()) }));
+
+const Penca = require('../models/Penca');
+const { isAuthenticated } = require('../middleware/auth');
+
+describe('GET /api/dashboard', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('returns pencas with scoring property', async () => {
+    const query = { select: jest.fn().mockResolvedValue([{ name: 'P1', scoring: { exact: 3 } }]) };
+    Penca.find.mockReturnValue(query);
+
+    const app = express();
+    app.use(session({ secret: 'test', resave: false, saveUninitialized: true }));
+    app.use((req, res, next) => {
+      req.session.user = { _id: 'u1', username: 'user', role: 'user' };
+      next();
+    });
+
+    app.get('/api/dashboard', isAuthenticated, async (req, res) => {
+      const { user } = req.session;
+      if (user.role === 'admin') {
+        return res.status(403).json({ error: 'ADMIN_ONLY' });
+      }
+      try {
+        const pencas = await Penca.find({ participants: user._id }).select('name _id competition fixture rules prizes scoring');
+        res.json({ user: { username: user.username, role: user.role }, pencas });
+      } catch (err) {
+        res.status(500).json({ error: 'DASHBOARD_ERROR' });
+      }
+    });
+
+    const res = await request(app).get('/api/dashboard');
+    expect(res.status).toBe(200);
+    expect(res.body.pencas[0]).toHaveProperty('scoring');
+    expect(query.select).toHaveBeenCalledWith('name _id competition fixture rules prizes scoring');
+  });
+});


### PR DESCRIPTION
## Summary
- request scoring field in dashboard API
- test dashboard API returns scoring data

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e479ee5648325821eceeeb0837730