### PR TITLE
Add calcPoints utility with unit tests

### DIFF
--- a/frontend/src/calcPoints.js
+++ b/frontend/src/calcPoints.js
@@ -1,0 +1,19 @@
+export default function pointsForPrediction(prediction, match, scoring = { exact: 3, outcome: 1, goals: 1 }) {
+  let pts = 0;
+  if (!prediction || !match) return pts;
+  if (match.result1 !== undefined && match.result2 !== undefined) {
+    if (prediction.result1 === match.result1 && prediction.result2 === match.result2) {
+      pts += scoring.exact;
+    } else if (
+      (prediction.result1 > prediction.result2 && match.result1 > match.result2) ||
+      (prediction.result1 < prediction.result2 && match.result1 < match.result2) ||
+      (prediction.result1 === prediction.result2 && match.result1 === match.result2)
+    ) {
+      pts += scoring.outcome;
+    }
+    if (prediction.result1 === match.result1 || prediction.result2 === match.result2) {
+      pts += scoring.goals;
+    }
+  }
+  return pts;
+}

--- a/tests/calcPoints.test.js
+++ b/tests/calcPoints.test.js
@@ -1,0 +1,46 @@
+let pointsForPrediction;
+
+beforeAll(async () => {
+  pointsForPrediction = (await import('../frontend/src/calcPoints.js')).default;
+});
+
+describe('pointsForPrediction', () => {
+  const scoring = { exact: 3, outcome: 1, goals: 1 };
+
+  test('awards exact and goal points for perfect prediction', () => {
+    const pred = { result1: 2, result2: 1 };
+    const match = { result1: 2, result2: 1 };
+    expect(pointsForPrediction(pred, match, scoring)).toBe(4);
+  });
+
+  test('awards outcome points only when no goals match', () => {
+    const pred = { result1: 1, result2: 0 };
+    const match = { result1: 2, result2: 1 };
+    expect(pointsForPrediction(pred, match, scoring)).toBe(1);
+  });
+
+  test('awards goal points when outcome is wrong but one score matches', () => {
+    const pred = { result1: 2, result2: 3 };
+    const match = { result1: 2, result2: 1 };
+    expect(pointsForPrediction(pred, match, scoring)).toBe(1);
+  });
+
+  test('awards outcome and goal points when outcome correct and one score matches', () => {
+    const pred = { result1: 3, result2: 1 };
+    const match = { result1: 2, result2: 1 };
+    expect(pointsForPrediction(pred, match, scoring)).toBe(2);
+  });
+
+  test('returns zero when nothing matches', () => {
+    const pred = { result1: 0, result2: 2 };
+    const match = { result1: 1, result2: 0 };
+    expect(pointsForPrediction(pred, match, scoring)).toBe(0);
+  });
+
+  test('uses custom scoring values', () => {
+    const pred = { result1: 1, result2: 1 };
+    const match = { result1: 1, result2: 1 };
+    const custom = { exact: 5, outcome: 2, goals: 1 };
+    expect(pointsForPrediction(pred, match, custom)).toBe(6);
+  });
+});


### PR DESCRIPTION
## Summary
- add frontend helper for calculating points
- cover scoring logic via unit tests

## Testing
- `npm install --silent` *(fails: network access blocked)*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e58cb870c8325b199fc9c6877da6c