### PR TITLE
Show prediction results and points

### DIFF
--- a/frontend/src/PencaSection.jsx
+++ b/frontend/src/PencaSection.jsx
@@ -26,6 +26,7 @@ import InfoOutlined from '@mui/icons-material/InfoOutlined';
 import GroupTable from './GroupTable';
 import roundOrder from './roundOrder';
 import useLang from './useLang';
+import pointsForPrediction from './calcPoints';
 
 export default function PencaSection({ penca, matches, groups, getPrediction, handlePrediction, ranking }) {
   const [open, setOpen] = useState(false);
@@ -139,6 +140,17 @@ export default function PencaSection({ penca, matches, groups, getPrediction, ha
                                   <Button variant="contained" type="submit" disabled={!editable}>{t('save')}</Button>
                                 </form>
                               </div>
+                              {m.result1 !== undefined && m.result2 !== undefined && (
+                                <div className="match-info">
+                                  <strong>{m.result1} - {m.result2}</strong>
+                                  {pr.result1 !== undefined && pr.result2 !== undefined && (
+                                    <>
+                                      {' '}({pr.result1 - m.result1}/{pr.result2 - m.result2})
+                                      <span className="points-earned">{pointsForPrediction(pr, m, penca.scoring)} {t('pts')}</span>
+                                    </>
+                                  )}
+                                </div>
+                              )}
                             </CardContent>
                           </Card>
                         );
@@ -199,6 +211,17 @@ export default function PencaSection({ penca, matches, groups, getPrediction, ha
                                       <Button variant="contained" type="submit" disabled={!editable}>{t('save')}</Button>
                                     </form>
                                   </div>
+                                  {m.result1 !== undefined && m.result2 !== undefined && (
+                                    <div className="match-info">
+                                      <strong>{m.result1} - {m.result2}</strong>
+                                      {pr.result1 !== undefined && pr.result2 !== undefined && (
+                                        <>
+                                          {' '}({pr.result1 - m.result1}/{pr.result2 - m.result2})
+                                          <span className="points-earned">{pointsForPrediction(pr, m, penca.scoring)} {t('pts')}</span>
+                                        </>
+                                      )}
+                                    </div>
+                                  )}
                                 </CardContent>
                               </Card>
                             );

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -164,6 +164,16 @@ footer {
     margin-top: 10px;
     width: 100%;
 }
+.match-info {
+    margin-top: 5px;
+    text-align: center;
+    font-size: 0.9rem;
+}
+.points-earned {
+    font-weight: bold;
+    color: #28a745;
+    margin-left: 5px;
+}
 
 @media (min-width: 600px) {
     .match-details {

--- a/public/scss/_match.scss
+++ b/public/scss/_match.scss
@@ -73,6 +73,18 @@
     width: 100%;
 }
 
+.match-info {
+    margin-top: 5px;
+    text-align: center;
+    font-size: 0.9rem;
+}
+
+.points-earned {
+    font-weight: bold;
+    color: #28a745;
+    margin-left: 5px;
+}
+
 @media (min-width: 600px) {
     .match-details {
         flex-direction: row;


### PR DESCRIPTION
## Summary
- import the `pointsForPrediction` helper
- display match results after each prediction form
- show goal difference and points earned
- add `.match-info` and `.points-earned` styles
- regenerate compiled CSS

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e5a4f02288325b400c1e5bb09c7ec