### PR TITLE
Update PencaSection translations

### DIFF
--- a/frontend/src/PencaSection.jsx
+++ b/frontend/src/PencaSection.jsx
@@ -106,7 +106,7 @@ export default function PencaSection({ penca, matches, groups, getPrediction, ha
                                   <img src={`/images/${m.team1.replace(/\s+/g, '').toLowerCase()}.png`} alt={m.team1} className="circle responsive-img" />
                                   <span className="team-name">{m.team1}</span>
                                 </div>
-                                <span className="vs">vs</span>
+                                <span className="vs">{t('vs')}</span>
                                 <div className="team">
                                   <img src={`/images/${m.team2.replace(/\s+/g, '').toLowerCase()}.png`} alt={m.team2} className="circle responsive-img" />
                                   <span className="team-name">{m.team2}</span>
@@ -142,11 +142,11 @@ export default function PencaSection({ penca, matches, groups, getPrediction, ha
                               </div>
                               {m.result1 !== undefined && m.result2 !== undefined && (
                                 <div className="match-info">
-                                  <strong>{m.result1} - {m.result2}</strong>
+                                  <strong>{t('result')}: {m.result1} - {m.result2}</strong>
                                   {pr.result1 !== undefined && pr.result2 !== undefined && (
                                     <>
-                                      {' '}({pr.result1 - m.result1}/{pr.result2 - m.result2})
-                                      <span className="points-earned">{pointsForPrediction(pr, m, penca.scoring)} {t('pts')}</span>
+                                      {' '}{t('difference')}: ({pr.result1 - m.result1}/{pr.result2 - m.result2})
+                                      <span className="points-earned">{t('pointsEarned')}: {pointsForPrediction(pr, m, penca.scoring)} {t('pts')}</span>
                                     </>
                                   )}
                                 </div>
@@ -177,7 +177,7 @@ export default function PencaSection({ penca, matches, groups, getPrediction, ha
                                       <img src={`/images/${m.team1.replace(/\s+/g, '').toLowerCase()}.png`} alt={m.team1} className="circle responsive-img" />
                                       <span className="team-name">{m.team1}</span>
                                     </div>
-                                    <span className="vs">vs</span>
+                                    <span className="vs">{t('vs')}</span>
                                     <div className="team">
                                       <img src={`/images/${m.team2.replace(/\s+/g, '').toLowerCase()}.png`} alt={m.team2} className="circle responsive-img" />
                                       <span className="team-name">{m.team2}</span>
@@ -213,11 +213,11 @@ export default function PencaSection({ penca, matches, groups, getPrediction, ha
                                   </div>
                                   {m.result1 !== undefined && m.result2 !== undefined && (
                                     <div className="match-info">
-                                      <strong>{m.result1} - {m.result2}</strong>
+                                      <strong>{t('result')}: {m.result1} - {m.result2}</strong>
                                       {pr.result1 !== undefined && pr.result2 !== undefined && (
                                         <>
-                                          {' '}({pr.result1 - m.result1}/{pr.result2 - m.result2})
-                                          <span className="points-earned">{pointsForPrediction(pr, m, penca.scoring)} {t('pts')}</span>
+                                          {' '}{t('difference')}: ({pr.result1 - m.result1}/{pr.result2 - m.result2})
+                                          <span className="points-earned">{t('pointsEarned')}: {pointsForPrediction(pr, m, penca.scoring)} {t('pts')}</span>
                                         </>
                                       )}
                                     </div>
@@ -258,7 +258,7 @@ export default function PencaSection({ penca, matches, groups, getPrediction, ha
                                 <img src={`/images/${m.team1.replace(/\s+/g, '').toLowerCase()}.png`} alt={m.team1} className="circle responsive-img" />
                                 <span className="team-name">{m.team1}</span>
                               </div>
-                              <span className="vs">vs</span>
+                              <span className="vs">{t('vs')}</span>
                               <div className="team">
                                 <img src={`/images/${m.team2.replace(/\s+/g, '').toLowerCase()}.png`} alt={m.team2} className="circle responsive-img" />
                                 <span className="team-name">{m.team2}</span>
@@ -290,7 +290,7 @@ export default function PencaSection({ penca, matches, groups, getPrediction, ha
                                 <img src={`/images/${m.team1.replace(/\s+/g, '').toLowerCase()}.png`} alt={m.team1} className="circle responsive-img" />
                                 <span className="team-name">{m.team1}</span>
                               </div>
-                              <span className="vs">vs</span>
+                              <span className="vs">{t('vs')}</span>
                               <div className="team">
                                 <img src={`/images/${m.team2.replace(/\s+/g, '').toLowerCase()}.png`} alt={m.team2} className="circle responsive-img" />
                                 <span className="team-name">{m.team2}</span>

--- a/frontend/src/strings.js
+++ b/frontend/src/strings.js
@@ -66,7 +66,10 @@ const strings = {
     d: 'D',
     l: 'L',
     gd: 'DG',
-    gf: 'GF'
+    gf: 'GF',
+    result: 'Resultado',
+    pointsEarned: 'Puntos',
+    difference: 'Diferencia'
   },
   en: {
     loginTitle: 'Login',
@@ -135,7 +138,10 @@ const strings = {
     d: 'D',
     l: 'L',
     gd: 'GD',
-    gf: 'GF'
+    gf: 'GF',
+    result: 'Result',
+    pointsEarned: 'Points',
+    difference: 'Difference'
   }
 };
 


### PR DESCRIPTION
## Summary
- add extra translation keys for result display
- use translated labels in `PencaSection` and replace hard-coded "vs"

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e5c302aa88325b55bfcaa5ab11546