### PR TITLE
Highlight current user in ranking

### DIFF
--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -149,6 +149,7 @@ export default function Dashboard() {
           getPrediction={getPrediction}
           handlePrediction={handlePrediction}
           ranking={rankings[p._id] || []}
+          currentUsername={user?.username}
         />
       ))}
       {pencas.length > 0 && (

--- a/frontend/src/PencaSection.jsx
+++ b/frontend/src/PencaSection.jsx
@@ -28,7 +28,7 @@ import roundOrder from './roundOrder';
 import useLang from './useLang';
 import pointsForPrediction from './calcPoints';
 
-export default function PencaSection({ penca, matches, groups, getPrediction, handlePrediction, ranking }) {
+export default function PencaSection({ penca, matches, groups, getPrediction, handlePrediction, ranking, currentUsername }) {
   const [open, setOpen] = useState(false);
   const [infoOpen, setInfoOpen] = useState(false);
   const { t } = useLang();
@@ -327,7 +327,10 @@ export default function PencaSection({ penca, matches, groups, getPrediction, ha
                     </TableHead>
                     <TableBody>
                       {ranking.map((u, idx) => (
-                        <TableRow key={u.userId} className={`rank-${idx + 1}`.trim()}>
+                        <TableRow
+                          key={u.userId}
+                          className={`rank-${idx + 1} ${u.username === currentUsername ? 'current-user-row' : ''}`.trim()}
+                        >
                           <TableCell>{idx + 1}</TableCell>
                           <TableCell>
                             <img

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -333,6 +333,11 @@ footer {
     background: linear-gradient(to right, #ffe0b2, #fff3e0);
 }
 
+.current-user-row {
+    background-color: #e0f7fa;
+    font-weight: bold;
+}
+
 /* === Utils === */
 .center-align {
     text-align: center;


### PR DESCRIPTION
## Summary
- pass username prop to `PencaSection`
- mark row of the logged user in ranking tables
- add styles for the current user row

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e77706de88325a1e99e8441109ec5