### PR TITLE
Implement match filtering

### DIFF
--- a/frontend/src/OwnerPanel.jsx
+++ b/frontend/src/OwnerPanel.jsx
@@ -19,6 +19,7 @@ export default function OwnerPanel() {
   const [matches, setMatches] = useState([]);
   const { t } = useLang();
   const [expandedPenca, setExpandedPenca] = useState(null);
+  const [filter, setFilter] = useState('all');
 
 
   useEffect(() => {
@@ -140,6 +141,11 @@ export default function OwnerPanel() {
     list.sort(
       (a, b) => new Date(`${a.date}T${a.time}`) - new Date(`${b.date}T${b.time}`)
     );
+    if (filter === 'upcoming') {
+      list = list.filter(m => m.result1 == null && m.result2 == null);
+    } else if (filter === 'played') {
+      list = list.filter(m => m.result1 != null && m.result2 != null);
+    }
     const grouped = {};
     list.forEach(m => {
       const g = m.group_name || 'Otros';
@@ -152,6 +158,17 @@ export default function OwnerPanel() {
   return (
     <div className="container" style={{ marginTop: '2rem' }}>
       <h5>{t('ownerMyPencas')}</h5>
+      <div style={{ marginBottom: '0.5rem' }}>
+        <Button size="small" variant={filter === 'all' ? 'contained' : 'outlined'} onClick={() => setFilter('all')} sx={{ mr: 1 }}>
+          {t('allMatches')}
+        </Button>
+        <Button size="small" variant={filter === 'upcoming' ? 'contained' : 'outlined'} onClick={() => setFilter('upcoming')} sx={{ mr: 1 }}>
+          {t('upcoming')}
+        </Button>
+        <Button size="small" variant={filter === 'played' ? 'contained' : 'outlined'} onClick={() => setFilter('played')}>
+          {t('played')}
+        </Button>
+      </div>
       {pencas.map(p => {
         const ranking = rankings[p._id] || [];
         const pMatches = filterMatches(p);

--- a/frontend/src/PencaSection.jsx
+++ b/frontend/src/PencaSection.jsx
@@ -31,6 +31,7 @@ import pointsForPrediction from './calcPoints';
 export default function PencaSection({ penca, matches, groups, getPrediction, handlePrediction, ranking, currentUsername }) {
   const [open, setOpen] = useState(false);
   const [infoOpen, setInfoOpen] = useState(false);
+  const [filter, setFilter] = useState('all');
   const { t } = useLang();
 
   function canPredict(match) {
@@ -47,6 +48,11 @@ export default function PencaSection({ penca, matches, groups, getPrediction, ha
       list = matches.filter(m => m.competition === penca.competition);
     }
     list.sort((a, b) => new Date(`${a.date}T${a.time}`) - new Date(`${b.date}T${b.time}`));
+    if (filter === 'upcoming') {
+      list = list.filter(m => m.result1 == null && m.result2 == null);
+    } else if (filter === 'played') {
+      list = list.filter(m => m.result1 != null && m.result2 != null);
+    }
     const grouped = {};
     list.forEach(m => {
       const g = m.group_name || 'Otros';
@@ -77,6 +83,17 @@ export default function PencaSection({ penca, matches, groups, getPrediction, ha
       {open && ( 
         <Card style={{ marginTop: '0', borderTop: 'none', padding: '1rem' }}>
           <CardContent>
+            <div style={{ marginBottom: '0.5rem' }}>
+              <Button size="small" variant={filter === 'all' ? 'contained' : 'outlined'} onClick={() => setFilter('all')} sx={{ mr: 1 }}>
+                {t('allMatches')}
+              </Button>
+              <Button size="small" variant={filter === 'upcoming' ? 'contained' : 'outlined'} onClick={() => setFilter('upcoming')} sx={{ mr: 1 }}>
+                {t('upcoming')}
+              </Button>
+              <Button size="small" variant={filter === 'played' ? 'contained' : 'outlined'} onClick={() => setFilter('played')}>
+                {t('played')}
+              </Button>
+            </div>
             <Accordion>
               <AccordionSummary expandIcon="▶">
                 <Typography>{t('predictions')}</Typography>

--- a/frontend/src/strings.js
+++ b/frontend/src/strings.js
@@ -71,7 +71,10 @@ const strings = {
     gf: 'GF',
     result: 'Resultado',
     pointsEarned: 'Puntos',
-    difference: 'Diferencia'
+    difference: 'Diferencia',
+    allMatches: 'Todos',
+    upcoming: 'Próximos',
+    played: 'Jugados'
   },
   en: {
     loginTitle: 'Login',
@@ -145,7 +148,10 @@ const strings = {
     gf: 'GF',
     result: 'Result',
     pointsEarned: 'Points',
-    difference: 'Difference'
+    difference: 'Difference',
+    allMatches: 'All',
+    upcoming: 'Upcoming',
+    played: 'Played'
   }
 };
 


### PR DESCRIPTION
## Summary
- add filter state and buttons in OwnerPanel and PencaSection
- filter matches based on selected option
- provide translation strings for filter labels

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e857b578c8325917c95d4f149e3aa