### PR TITLE
Add snackbar feedback on prediction save

### DIFF
--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -114,13 +114,19 @@ export default function Dashboard() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ ...data, pencaId, matchId })
       });
+      const result = await res.json();
       if (res.ok) {
-        const updated = predictions.filter(p => !(p.pencaId === pencaId && p.matchId === matchId && p.username === user.username));
+        const updated = predictions.filter(
+          p => !(p.pencaId === pencaId && p.matchId === matchId && p.username === user.username)
+        );
         updated.push({ pencaId, matchId, result1: Number(data.result1), result2: Number(data.result2), username: user.username });
         setPredictions(updated);
+        return { success: true, message: result.message || 'OK' };
       }
+      return { success: false, error: result.error || 'Error' };
     } catch (err) {
       console.error('save prediction error', err);
+      return { success: false, error: t('networkError') };
     }
   };
 

--- a/frontend/src/PencaSection.jsx
+++ b/frontend/src/PencaSection.jsx
@@ -19,7 +19,9 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  Paper
+  Paper,
+  Snackbar,
+  Alert
 
 } from '@mui/material';
 import InfoOutlined from '@mui/icons-material/InfoOutlined';
@@ -32,12 +34,22 @@ export default function PencaSection({ penca, matches, groups, getPrediction, ha
   const [open, setOpen] = useState(false);
   const [infoOpen, setInfoOpen] = useState(false);
   const [filter, setFilter] = useState('all');
+  const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'success' });
   const { t } = useLang();
 
   function canPredict(match) {
     const start = new Date(`${match.date}T${match.time}:00`);
     const diff = (start - new Date()) / 60000;
     return diff >= 30;
+  }
+
+  async function submitPrediction(e, pencaId, matchId) {
+    const result = await handlePrediction(e, pencaId, matchId);
+    if (result?.success) {
+      setSnackbar({ open: true, message: result.message, severity: 'success' });
+    } else {
+      setSnackbar({ open: true, message: result?.error || t('networkError'), severity: 'error' });
+    }
   }
 
   const pMatches = (() => {
@@ -130,7 +142,7 @@ export default function PencaSection({ penca, matches, groups, getPrediction, ha
                                 </div>
                               </div>
                               <div className="match-details">
-                                <form onSubmit={e => handlePrediction(e, penca._id, m._id)}>
+                                <form onSubmit={e => submitPrediction(e, penca._id, m._id)}>
                                   <div className="input-field inline">
                                     <TextField
                                       name="result1"
@@ -201,7 +213,7 @@ export default function PencaSection({ penca, matches, groups, getPrediction, ha
                                     </div>
                                   </div>
                                   <div className="match-details">
-                                    <form onSubmit={e => handlePrediction(e, penca._id, m._id)}>
+                                    <form onSubmit={e => submitPrediction(e, penca._id, m._id)}>
                                       <div className="input-field inline">
                                         <TextField
                                           name="result1"
@@ -390,6 +402,23 @@ export default function PencaSection({ penca, matches, groups, getPrediction, ha
           <Button onClick={() => setInfoOpen(false)}>{t('close')}</Button>
         </DialogActions>
       </Dialog>
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={3000}
+        onClose={(_, reason) => {
+          if (reason === 'clickaway') return;
+          setSnackbar(s => ({ ...s, open: false }));
+        }}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          severity={snackbar.severity}
+          onClose={() => setSnackbar(s => ({ ...s, open: false }))}
+          sx={{ width: '100%' }}
+        >
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- return success/error info from `handlePrediction`
- show feedback in `PencaSection` via `Snackbar` + `Alert`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e867a34b08325b33cdc410598a100