### PR TITLE
Implement automatic results updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ FOOTBALL_LEAGUE_ID=<id_liga>
 FOOTBALL_SEASON=<temporada>
 # URL base opcional de la API
 FOOTBALL_API_URL=https://v3.football.api-sports.io
+# Intervalo mínimo entre actualizaciones de resultados (ms)
+FOOTBALL_UPDATE_INTERVAL=3600000
 ```
 Si no defines `SESSION_SECRET`, el servidor se cerrará al iniciarse.
 El valor `MAX_PENCAS_PER_USER` controla cuántas pencas puede integrar cada usuario,
@@ -130,6 +132,7 @@ encuentros de forma agrupada. Al guardar un resultado la aplicación actualiza
 automáticamente la llave del knockout. El endpoint
 `/admin/recalculate-bracket` (botón *Recalcular bracket* en el panel) queda como
 opción de respaldo para recalcular manualmente si fuera necesario.
+También puedes usar `/admin/update-results/<competencia>` para obtener marcadores directamente desde API‑Football. La frecuencia de actualización se controla con la variable `FOOTBALL_UPDATE_INTERVAL`.
 
 ### Ejemplo de uso
 
@@ -143,6 +146,7 @@ opción de respaldo para recalcular manualmente si fuera necesario.
 - `GET /bracket` – muestra la llave del knockout según la última recalculación.
 - `POST /admin/recalculate-bracket` – fuerza el nuevo cálculo del bracket con
   los resultados cargados.
+- `POST /admin/update-results/:competition` – obtiene los resultados desde la API-Football.
 - `GET /api/owner` – devuelve las pencas administradas por el owner autenticado.
 - `GET /competitions/:competition/matches` – lista los partidos de la competencia indicada.
 

--- a/models/ApiUsage.js
+++ b/models/ApiUsage.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose');
+
+const apiUsageSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  competition: { type: String },
+  lastUsed: { type: Date, default: Date.now }
+});
+
+module.exports = mongoose.models.ApiUsage || mongoose.model('ApiUsage', apiUsageSchema);

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -10,6 +10,7 @@ const Competition = require('../models/Competition');
 const { isAuthenticated, isAdmin } = require('../middleware/auth');
 const { DEFAULT_COMPETITION } = require('../config');
 const { updateEliminationMatches, generateEliminationBracket } = require('../utils/bracket');
+const updateResults = require('../scripts/updateResults');
 
 const storage = multer.memoryStorage();
 const upload = multer({ 
@@ -524,6 +525,17 @@ router.post('/recalculate-bracket/:competition', isAuthenticated, isAdmin, async
         res.json({ message: 'Bracket recalculated' });
     } catch (error) {
         console.error('Error recalculating bracket:', error);
+        res.status(500).json({ error: 'Internal server error' });
+    }
+});
+
+// Actualizar resultados desde API-Football
+router.post('/update-results/:competition', isAuthenticated, isAdmin, async (req, res) => {
+    try {
+        await updateResults(req.params.competition);
+        res.json({ message: 'Results updated' });
+    } catch (error) {
+        console.error('Error updating results:', error);
         res.status(500).json({ error: 'Internal server error' });
     }
 });

--- a/scripts/updateResults.js
+++ b/scripts/updateResults.js
@@ -1,0 +1,50 @@
+const Match = require('../models/Match');
+const ApiUsage = require('../models/ApiUsage');
+
+async function updateResults(competition) {
+  const {
+    FOOTBALL_API_KEY,
+    FOOTBALL_LEAGUE_ID,
+    FOOTBALL_SEASON,
+    FOOTBALL_API_URL,
+    FOOTBALL_UPDATE_INTERVAL
+  } = process.env;
+
+  if (!FOOTBALL_API_KEY || !FOOTBALL_LEAGUE_ID || !FOOTBALL_SEASON) {
+    throw new Error('Football API env vars missing');
+  }
+
+  const interval = parseInt(FOOTBALL_UPDATE_INTERVAL || '3600000', 10);
+  const usage = await ApiUsage.findOne({ name: 'updateResults', competition });
+  if (usage && Date.now() - usage.lastUsed.getTime() < interval) {
+    return { skipped: true };
+  }
+
+  const base = FOOTBALL_API_URL || 'https://v3.football.api-sports.io';
+  const url = `${base}/fixtures?league=${FOOTBALL_LEAGUE_ID}&season=${FOOTBALL_SEASON}`;
+  const response = await fetch(url, { headers: { 'x-apisports-key': FOOTBALL_API_KEY } });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch fixtures: ${response.status}`);
+  }
+
+  const apiData = await response.json();
+  const fixtures = apiData.response || [];
+  for (const f of fixtures) {
+    const id = String(f.fixture?.id || '');
+    const result1 = f.goals?.home ?? null;
+    const result2 = f.goals?.away ?? null;
+    await Match.updateOne({ series: id, competition }, { result1, result2 });
+  }
+
+  if (usage) {
+    usage.lastUsed = new Date();
+    await usage.save();
+  } else {
+    await ApiUsage.create({ name: 'updateResults', competition, lastUsed: new Date() });
+  }
+
+  return { updated: fixtures.length };
+}
+
+module.exports = updateResults;

--- a/tests/updateResults.test.js
+++ b/tests/updateResults.test.js
@@ -1,0 +1,66 @@
+const updateResults = require('../scripts/updateResults');
+
+jest.mock('../models/Match', () => ({
+  updateOne: jest.fn()
+}));
+
+jest.mock('../models/ApiUsage', () => ({
+  findOne: jest.fn(),
+  create: jest.fn()
+}));
+
+const Match = require('../models/Match');
+const ApiUsage = require('../models/ApiUsage');
+
+describe('updateResults script', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+    process.env.FOOTBALL_API_KEY = 'k';
+    process.env.FOOTBALL_LEAGUE_ID = '1';
+    process.env.FOOTBALL_SEASON = '2024';
+    process.env.FOOTBALL_API_URL = 'http://api';
+    process.env.FOOTBALL_UPDATE_INTERVAL = '3600000';
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('updates matches from API', async () => {
+    ApiUsage.findOne.mockResolvedValue(null);
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        response: [
+          {
+            fixture: { id: 10 },
+            goals: { home: 2, away: 1 }
+          }
+        ]
+      })
+    });
+
+    const res = await updateResults('Copa');
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://api/fixtures?league=1&season=2024',
+      { headers: { 'x-apisports-key': 'k' } }
+    );
+    expect(Match.updateOne).toHaveBeenCalledWith(
+      { series: '10', competition: 'Copa' },
+      { result1: 2, result2: 1 }
+    );
+    expect(ApiUsage.create).toHaveBeenCalled();
+    expect(res.updated).toBe(1);
+  });
+
+  it('skips when called before interval', async () => {
+    ApiUsage.findOne.mockResolvedValue({ lastUsed: new Date() });
+
+    const res = await updateResults('Copa');
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(Match.updateOne).not.toHaveBeenCalled();
+    expect(res.skipped).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- create `ApiUsage` model
- add script `scripts/updateResults.js` to update match results from API‑Football
- add `/admin/update-results/:competition` route
- document `FOOTBALL_UPDATE_INTERVAL` and new endpoint
- add tests for update script

## Testing
- `npm ci` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687eec9810ec83258778987677099907