### PR TITLE
Update bracket after result updates

### DIFF
--- a/scripts/updateResults.js
+++ b/scripts/updateResults.js
@@ -1,5 +1,6 @@
 const Match = require('../models/Match');
 const { fetchFixturesWithThrottle } = require('./apiFootball');
+const { updateEliminationMatches } = require('../utils/bracket');
 
 async function updateResults(competition) {
   const { fixtures, skipped } = await fetchFixturesWithThrottle('updateResults', competition);
@@ -12,6 +13,8 @@ async function updateResults(competition) {
     const result2 = f.goals?.away ?? null;
     await Match.updateOne({ series: id, competition }, { result1, result2 });
   }
+
+  await updateEliminationMatches(competition);
 
   return { updated: fixtures.length };
 }

--- a/tests/updateResults.test.js
+++ b/tests/updateResults.test.js
@@ -4,6 +4,10 @@ jest.mock('../models/Match', () => ({
   updateOne: jest.fn()
 }));
 
+jest.mock('../utils/bracket', () => ({
+  updateEliminationMatches: jest.fn()
+}));
+
 jest.mock('../models/ApiUsage', () => ({
   findOne: jest.fn(),
   create: jest.fn()
@@ -11,6 +15,7 @@ jest.mock('../models/ApiUsage', () => ({
 
 const Match = require('../models/Match');
 const ApiUsage = require('../models/ApiUsage');
+const { updateEliminationMatches } = require('../utils/bracket');
 
 describe('updateResults script', () => {
   beforeEach(() => {
@@ -50,6 +55,7 @@ describe('updateResults script', () => {
       { series: '10', competition: 'Copa' },
       { result1: 2, result2: 1 }
     );
+    expect(updateEliminationMatches).toHaveBeenCalledWith('Copa');
     expect(ApiUsage.create).toHaveBeenCalled();
     expect(res.updated).toBe(1);
   });
@@ -61,6 +67,7 @@ describe('updateResults script', () => {
 
     expect(global.fetch).not.toHaveBeenCalled();
     expect(Match.updateOne).not.toHaveBeenCalled();
+    expect(updateEliminationMatches).not.toHaveBeenCalled();
     expect(res.skipped).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- ensure knockout stage updates when results are refreshed
- expect updateEliminationMatches call in updateResults tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ef915bcd483259874a59909e4bd1d