### PR TITLE
Add competition metadata support

### DIFF
--- a/models/Competition.js
+++ b/models/Competition.js
@@ -5,6 +5,10 @@ const competitionSchema = new mongoose.Schema({
     groupsCount: Number,
     integrantsPerGroup: Number,
     qualifiersPerGroup: Number,
+    tournament: String,
+    country: String,
+    seasonStart: Date,
+    seasonEnd: Date,
     apiLeagueId: Number,
     apiSeason: Number
 });


### PR DESCRIPTION
## Summary
- store extra competition fields like tournament name, country and season dates
- fetch league metadata when creating competitions with API
- allow updating new competition fields via admin routes
- update admin tests for new behavior

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fc7f58dac8325a46cc4fddfdb4913