### PR TITLE
Validate inputs for admin preview endpoint

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -262,11 +262,14 @@ router.delete('/pencas/:id', isAuthenticated, isAdmin, async (req, res) => {
 router.post('/competitions/preview', isAuthenticated, isAdmin, async (req, res) => {
     try {
         const { apiLeagueId, apiSeason } = req.body;
-        if (!apiLeagueId || !apiSeason) {
-            return res.status(400).json({ error: 'apiLeagueId and apiSeason required' });
+        const leagueId = Number(apiLeagueId);
+        const season = Number(apiSeason);
+        if (!Number.isInteger(leagueId) || leagueId <= 0 ||
+            !Number.isInteger(season) || season <= 0) {
+            return res.status(400).json({ error: 'Invalid apiLeagueId or apiSeason' });
         }
 
-        const { league, fixtures } = await fetchCompetitionData(Number(apiLeagueId), Number(apiSeason));
+        const { league, fixtures } = await fetchCompetitionData(leagueId, season);
         const groupsMap = {};
         const matches = fixtures.map(f => {
             const group = f.league?.group || f.league?.round || '';

--- a/tests/admin.preview.test.js
+++ b/tests/admin.preview.test.js
@@ -41,4 +41,17 @@ describe('Admin competition preview', () => {
     expect(res.body.matches.length).toBe(1);
     expect(res.body.groups[0]).toEqual({ name: 'Grupo A', teams: ['A', 'B'] });
   });
+
+  it('returns 400 for invalid input', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use('/admin', adminRouter);
+
+    const res = await request(app)
+      .post('/admin/competitions/preview')
+      .send({ apiLeagueId: 'x', apiSeason: 2024 });
+
+    expect(res.status).toBe(400);
+    expect(fetchCompetitionData).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- validate `apiLeagueId` and `apiSeason` as positive integers in admin preview endpoint
- test invalid inputs for the preview route

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68852a56d5448325b7493fc4f8699388