### PR TITLE
Handle skipped results in admin route

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -621,7 +621,10 @@ router.post('/recalculate-bracket/:competition', isAuthenticated, isAdmin, async
 // Actualizar resultados desde API-Football
 router.post('/update-results/:competition', isAuthenticated, isAdmin, async (req, res) => {
     try {
-        await updateResults(req.params.competition);
+        const result = await updateResults(req.params.competition);
+        if (result && result.skipped) {
+            return res.json({ skipped: true });
+        }
         res.json({ message: 'Results updated' });
     } catch (error) {
         console.error('Error updating results:', error);

--- a/tests/admin.updateResults.route.test.js
+++ b/tests/admin.updateResults.route.test.js
@@ -1,0 +1,40 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../scripts/updateResults');
+jest.mock('../middleware/auth', () => ({
+  isAuthenticated: jest.fn((req, res, next) => next()),
+  isAdmin: jest.fn((req, res, next) => next())
+}));
+
+const updateResults = require('../scripts/updateResults');
+const adminRouter = require('../routes/admin');
+
+describe('Admin update results route', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('returns skipped when API call is throttled', async () => {
+    updateResults.mockResolvedValue({ skipped: true });
+
+    const app = express();
+    app.use('/admin', adminRouter);
+
+    const res = await request(app).post('/admin/update-results/Copa');
+
+    expect(res.status).toBe(200);
+    expect(updateResults).toHaveBeenCalledWith('Copa');
+    expect(res.body.skipped).toBe(true);
+  });
+
+  it('returns success message when results updated', async () => {
+    updateResults.mockResolvedValue({ updated: 1 });
+
+    const app = express();
+    app.use('/admin', adminRouter);
+
+    const res = await request(app).post('/admin/update-results/Copa');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ message: 'Results updated' });
+  });
+});


### PR DESCRIPTION
## Summary
- handle skipped results in `/admin/update-results/:competition`
- add tests for update results route

## Testing
- `npm ci` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68852a7e13e8832582301770c54511bd