### PR TITLE
Allow uploading JSON fixtures when creating competitions

### DIFF
--- a/middleware/jsonUpload.js
+++ b/middleware/jsonUpload.js
@@ -1,0 +1,16 @@
+const multer = require('multer');
+
+const storage = multer.memoryStorage();
+
+const uploadJson = multer({
+    storage,
+    fileFilter: (req, file, cb) => {
+        if (file.mimetype === 'application/json') {
+            cb(null, true);
+        } else {
+            cb(new Error('Solo se permiten archivos JSON'));
+        }
+    }
+});
+
+module.exports = uploadJson;


### PR DESCRIPTION
## Summary
- remove external API dependency for competition creation
- add JSON-only multer middleware and validate uploaded fixtures
- simplify tests and drop API-based competition creation

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/connect-mongo)*

------
https://chatgpt.com/codex/tasks/task_e_68a60a26aa4083258055999522392cb2