### PR TITLE
Validate match data and surface import errors

### DIFF
--- a/tests/admin.test.js
+++ b/tests/admin.test.js
@@ -142,7 +142,7 @@ describe('Admin competition creation', () => {
     app.use('/admin', adminRouter);
 
     const fixture = [
-      { team1: 'A', team2: 'B', group_name: 'Grupo A', series: 'Fase de grupos', tournament: 'Copa' }
+      { date: '2024-06-01', time: '10:00', team1: 'A', team2: 'B', group_name: 'Grupo A', series: 'Fase de grupos', tournament: 'Copa' }
     ];
 
     const res = await request(app)
@@ -165,7 +165,7 @@ describe('Admin competition creation', () => {
     app.use('/admin', adminRouter);
 
     const fixture = [
-      { team1: 'A', team2: 'B', group_name: 'Grupo A', series: 'Fase de grupos', tournament: 'Copa' }
+      { date: '2024-06-01', time: '10:00', team1: 'A', team2: 'B', group_name: 'Grupo A', series: 'Fase de grupos', tournament: 'Copa' }
     ];
 
     const res = await request(app)
@@ -179,6 +179,56 @@ describe('Admin competition creation', () => {
         expect.objectContaining({ team1: 'A', team2: 'B', competition: 'Copa' })
       ])
     );
+  });
+
+  it('rejects fixture missing required fields', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use('/admin', adminRouter);
+
+    const fixture = [
+      { date: '2024-06-01', team1: 'A', team2: 'B', group_name: 'Grupo A', series: 'Fase de grupos', tournament: 'Copa' }
+    ];
+
+    const res = await request(app)
+      .post('/admin/competitions')
+      .send({ name: 'Copa', fixture });
+
+    expect(res.status).toBe(400);
+    expect(Match.insertMany).not.toHaveBeenCalled();
+  });
+
+  it('rejects fixture with mismatched match count', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use('/admin', adminRouter);
+
+    const fixture = [
+      { date: '2024-06-01', time: '10:00', team1: 'A', team2: 'B', group_name: 'Grupo A', series: 'Fase de grupos', tournament: 'Copa' }
+    ];
+
+    const res = await request(app)
+      .post('/admin/competitions')
+      .send({ name: 'Copa', fixture, expectedMatches: 2 });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects duplicate matches', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use('/admin', adminRouter);
+
+    const fixture = [
+      { date: '2024-06-01', time: '10:00', team1: 'A', team2: 'B', group_name: 'Grupo A', series: 'Fase de grupos', tournament: 'Copa' },
+      { date: '2024-06-01', time: '10:00', team1: 'A', team2: 'B', group_name: 'Grupo A', series: 'Fase de grupos', tournament: 'Copa' }
+    ];
+
+    const res = await request(app)
+      .post('/admin/competitions')
+      .send({ name: 'Copa', fixture, expectedMatches: 2 });
+
+    expect(res.status).toBe(400);
   });
 
   it('lists competitions', async () => {


### PR DESCRIPTION
## Summary
- ensure uploaded matches include required metadata, detect duplicates, and validate expected match counts
- show validation errors in CompetitionWizard using MUI Snackbar/Alert
- test coverage for missing fields, duplicate matches, and count mismatches

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a60dc723b08325a47f8971abcb8fb4