### PR TITLE
Harden register/logout endpoints and make admin match-clear resilient

### DIFF
--- a/main.js
+++ b/main.js
@@ -350,18 +350,23 @@ app.post('/register', upload.single('avatar'), async (req, res) => {
     const avatarContentType = req.file ? req.file.mimetype : null;
     try {
         const normalizedEmail = (email || '').trim().toLowerCase();
-        if (!displayName || !displayName.trim()) {
+        const normalizedUsername = (username || '').trim();
+        const derivedDisplayName = (displayName || name || normalizedUsername).trim();
+        if (!normalizedUsername || !password || !normalizedEmail) {
+            return res.status(400).json({ error: 'username, password and email are required' });
+        }
+        if (!derivedDisplayName) {
             return res.status(400).json({ error: 'displayName is required' });
         }
-        const existingUser = await User.findOne({ $or: [{ username }, { email: normalizedEmail }] });
+        const existingUser = await User.findOne({ $or: [{ username: normalizedUsername }, { email: normalizedEmail }] });
         if (existingUser) {
             return res.status(400).json({ error: getMessage('USER_EXISTS', req.lang) });
         }
         const hashedPassword = await bcrypt.hash(password, 10);
         const user = new User({
-            username,
+            username: normalizedUsername,
             password: hashedPassword,
-            displayName: displayName.trim(),
+            displayName: derivedDisplayName,
             name,
             surname,
             email: normalizedEmail,
@@ -412,12 +417,20 @@ app.use('/matches', matchesRouter);
 app.use(profileRouter);
 
 app.post('/logout', (req, res) => {
+    if (!req.session) {
+        return res.json({ success: true, redirectUrl: '/' });
+    }
     req.session.destroy(err => {
         if (err) {
+            console.error('Error on logout:', err);
             return res.status(500).json({ error: getMessage('LOGOUT_ERROR', req.lang) });
         }
-        res.redirect('/');
+        res.json({ success: true, redirectUrl: '/' });
     });
+});
+
+app.get(['/register'], (req, res) => {
+    res.sendFile(path.join(__dirname, 'frontend', 'dist', 'index.html'));
 });
 
 app.use((req, res) => {

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -232,7 +232,11 @@ router.post('/matches/clear', isAuthenticated, isAdmin, async (req, res) => {
   try {
     const result = await Match.deleteMany({ competition: DEFAULT_COMPETITION });
     await invalidateMatchCache(DEFAULT_COMPETITION);
-    await rankingCache.invalidate({ competition: DEFAULT_COMPETITION });
+    try {
+      await rankingCache.invalidate({ competition: DEFAULT_COMPETITION });
+    } catch (cacheError) {
+      console.error('Error invalidating ranking cache after clearing matches:', cacheError);
+    }
     res.json({ message: 'Matches cleared', deleted: result.deletedCount || 0 });
   } catch (error) {
     console.error('Error clearing matches:', error);


### PR DESCRIPTION
### Motivation
- Prevent registration failures and 500s caused by partial or malformed payloads sent from the frontend.
- Fix SPA refresh/direct-navigation 404s for the `/register` route used by the React client.
- Avoid the entire matches-clear operation failing when ranking cache invalidation has intermittent errors.

### Description
- Normalize `username` and `email`, enforce required `username`, `password`, and `email`, and derive a fallback `displayName` from `displayName || name || username` in the `/register` handler (stores the normalized username and derived display name). (main.js)
- Change `/logout` to safely handle a missing session and return a JSON success response instead of redirecting, making it robust for `fetch()`-based clients. (main.js)
- Add a GET `/register` route that serves the React SPA entrypoint to prevent direct-navigation/refresh 404s. (main.js)
- Wrap `rankingCache.invalidate` in a `try/catch` inside the admin `/matches/clear` endpoint so cache invalidation errors are logged but do not cause the clear operation to fail. (routes/admin.js)

### Testing
- Performed static syntax checks with `node --check main.js`, which succeeded. 
- Performed static syntax checks with `node --check routes/admin.js`, which succeeded. 
- Attempted `npm install` and `npm test` but dependency installation is blocked in this environment (registry returned `403 Forbidden` for `connect-mongo`), so the full Jest test suite could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cecc30990c8325a042b443d864b77e)